### PR TITLE
RDS multi AZ

### DIFF
--- a/rds/README.md
+++ b/rds/README.md
@@ -22,6 +22,7 @@ module "db" {
   engine_version      = "13.2"
   publicly_accessible = false
   allocated_storage   = 100
+  multi_az            = false
 }
 ```
 

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -11,7 +11,7 @@ resource "aws_db_instance" "main" {
   password = var.password
   parameter_group_name = aws_db_parameter_group.postgres13.name
   apply_immediately = true
-  multi_az = false
+  multi_az = var.multi_az
   publicly_accessible = var.publicly_accessible
   deletion_protection = true
   vpc_security_group_ids = [

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -6,8 +6,12 @@ variable "environment" {}
 
 variable "instance_class" { default = "db.t3.micro" }
 variable "engine_version" { default = "13.2" }
-variable "publicly_accessible" { default = false }
 variable "allocated_storage" { default = 100 }
+
+variable "publicly_accessible" {
+  type    = bool
+  default = false
+}
 
 variable "multi_az" {
   type    = bool


### PR DESCRIPTION
- update readme
- allow setting `multi_az` (defaults to false, which is the current value) --> we should set this to `true` for production DBs