### PR TITLE
allow ecs to get more details of network interfaces

### DIFF
--- a/ecs/execution-role.tf
+++ b/ecs/execution-role.tf
@@ -55,7 +55,8 @@ resource "aws_iam_role_policy" "ecs-task-execution-policy" {
         "Action" : [
           "ecs:DescribeServices",
           "ecs:DescribeTasks",
-          "ecs:ListTasks"
+          "ecs:ListTasks",
+          "ec2:DescribeNetworkInterfaces"
         ],
         "Resource" : "*"
       },


### PR DESCRIPTION
```ruby
irb(main):015:0> x.send(:current_container).network_interfaces.first
=> #<struct Aws::ECS::Types::NetworkInterface attachment_id="11399055-6e93-4cad-b79f-45ed76569f2a", private_ipv_4_address="10.1.2.97", ipv6_address=nil>
```


currently, we only get the private IP address, however, we need to get the public IP v4 address for Bastion to be able to connect to the jump host.

later, we want to resolve this with an URL.