### PR TITLE
Add experimental ssh command for auto configure

### DIFF
--- a/vpn/ssh.tf
+++ b/vpn/ssh.tf
@@ -1,15 +1,15 @@
 terraform {
   required_providers {
     ssh = {
-      source = "loafoe/ssh"
+      source  = "loafoe/ssh"
       version = "1.0.0"
     }
   }
 }
 
 resource "ssh_resource" "init" {
-  host = aws_instance.main.public_ip
-  user = "ubuntu"
+  host        = aws_instance.main.public_ip
+  user        = "ubuntu"
   private_key = file("${var.key_name}.pem")
 
   commands = [
@@ -18,5 +18,5 @@ resource "ssh_resource" "init" {
 }
 
 output "access_info" {
-  value = try(jsondecode(ssh_ressource.init.result), {})
+  value = try(jsondecode(ssh_resource.init.result), {})
 }


### PR DESCRIPTION
*DRAFT*

Want to find a way to get the output of `ssh -c "sudo cat /opt/outline/access.txt"` to the outputs so we don't need the manual step.

This `ssh_resource` command runs, but it does not give access to the output currently.