### PR TITLE
Remove refs to traction/clients

### DIFF
--- a/ecs/README.md
+++ b/ecs/README.md
@@ -33,3 +33,15 @@ module "ecs" {
 ```
 
 `allow_internal_traffic_to_ports` allow traffic to given ports within the cluster, e.g. to call an internal service like a PDF renderer.
+
+## Health checks
+If you run apps in many different cloud environments (e.g. Heroku, RKE, EKS, ECS, Lambda, Cloud66), you want consistent health checks implemented for consistency.
+
+Kubernetes have an excellent methodology where they name their health check `/healthz` to not conflict with any other potential resource endpoint.
+
+[https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request)
+
+You should aim to have the following endpoint(s) implemented on all projects to work across any deployed environment:
+
+- `GET /healthz`
+- `GET /healthz/auth` - Optional, but allows to check for auth validity internally

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -29,8 +29,6 @@ variable "allowlisted_ssh_ips" {
 }
 
 # This is where the load balancer will send health check requests to the app containers
-# The default follows the methodology of Kubernetes, see: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request
-# Find more about our own standard for health checks here: https://www.notion.so/tractioneng/Health-Checks-2555294b70ce4af4849e8d0fefeb16f8
 variable "health_check_path" { default = "/healthz" }
 
 variable "grant_read_access_to_s3_arns" {


### PR DESCRIPTION
preparation for going open source﻿

searching through the codebase using the following regex:
```regex
(?:traction|corona|compensaid|squake|flight|voucher|reveneo|lih|lufthansa|tilla|fried|marc|signisto|qualie|filler)
```
it looks like the codebase is "clean".
![image](https://user-images.githubusercontent.com/20702503/135624903-c2a2156b-b465-4ab3-999d-66e2b4721e51.png)
