### PR TITLE
ignore engine version changes for RDS

### DIFF
--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -34,4 +34,11 @@ resource "aws_db_instance" "main" {
     Project     = var.project
     Environment = var.environment
   }
+
+  # Ignore engine version changes since AWS will auto-update minor version changes
+  lifecycle {
+    ignore_changes = [
+      engine_version,
+    ]
+  }
 }


### PR DESCRIPTION
terraform detects changes outside of terraform when AWS performs minor version engine updates. This is annoying.﻿
