### PR TITLE
ECS can write to S3 bucket (Rails ActiveStorage!)

### DIFF
--- a/ecs/README.md
+++ b/ecs/README.md
@@ -28,7 +28,8 @@ module "ecs" {
     "XX.XX.XX.XX/32", # e.g. a VPN
   ]
 
-  grant_read_access_to_s3_arns = []
+  grant_read_access_to_s3_arns  = []
+  grant_write_access_to_s3_arns = []
 }
 ```
 

--- a/ecs/execution-role.tf
+++ b/ecs/execution-role.tf
@@ -66,6 +66,16 @@ resource "aws_iam_role_policy" "ecs-task-execution-policy" {
           "s3:GetObject"
         ],
         "Resource" : var.grant_read_access_to_s3_arns
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:ListBucket",
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject"
+        ],
+        "Resource" : var.grant_write_access_to_s3_arns
       }
     ]
   })

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -35,3 +35,7 @@ variable "health_check_path" { default = "/healthz" }
 variable "grant_read_access_to_s3_arns" {
   default = []
 }
+
+variable "grant_write_access_to_s3_arns" {
+  default = []
+}


### PR DESCRIPTION
I need to upload files to a bucket using active storage. this requires at least the here added ACLs.

https://edgeguides.rubyonrails.org/active_storage_overview.html
> The core features of Active Storage require the following permissions: s3:ListBucket, s3:PutObject, s3:GetObject, and s3:DeleteObject. Public access additionally requires s3:PutObjectAcl. If you have additional upload options configured such as setting ACLs then additional permissions may be required.
﻿


changes to terraform plan after this PR, assuming the bucket name `storage.${local.domain_name}`:

```terraform
+ {
    + Action   = [
        + "s3:ListBucket",
        + "s3:GetObject",
        + "s3:PutObject",
        + "s3:DeleteObject",
      ]
    + Effect   = "Allow"
    + Resource = [
        + "arn:aws:s3:::storage.${local.domain_name}/*",
      ]
  },
```