### PR TITLE
Add CORS headers for private s3 buckets

### DIFF
--- a/s3-private/s3.tf
+++ b/s3-private/s3.tf
@@ -23,6 +23,13 @@ resource "aws_s3_bucket" "main" {
     }
   }
 
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT"]
+    allowed_origins = ["*"]
+    expose_headers  = ["ETag"]
+  }
+
   tags = {
     Name        = var.bucket_name
     Project     = var.project


### PR DESCRIPTION
We need this in order to upload files directly to S3 from our frontends.

Since we use multi tenant setups, we cannot give a list of allowed origins upfront.

A presigned url is required to upload, so the security risk of allowed origins is non existent.