### PR TITLE
Output HTTPS ALB ARN for ECS

### DIFF
--- a/ecs/outputs.tf
+++ b/ecs/outputs.tf
@@ -21,3 +21,8 @@ output "alb_security_group_id" {
 output "ecs_security_group_id" {
   value = aws_security_group.ecs.id
 }
+
+# Needed to attach additional ressources (e.g. certificates) to the ALB
+output "https_alb_listener_arn" {
+  value = aws_alb_listener.https.arn
+}


### PR DESCRIPTION
We need to be able to attach add﻿ multiple  certificates to  an ALB, see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_certificate


Unsure why tests for the S3 modules are failing. Code is untouched and locally, they are passing. (I guess, the lastest version is installed, which might have breaking changes ...)