### PR TITLE
[Chore] Replace S3 deprecated syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@
 !/tmp/pids/.keep
 
 # Special\Personal dev setup
-.vscode/*
 /.idea
 
 # os

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["hashicorp.terraform"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "[terraform]": {
+    "editor.defaultFormatter": "hashicorp.terraform",
+    "editor.formatOnSave": true,
+    "editor.formatOnSaveMode": "file"
+  },
+
+  "[terraform-vars]": {
+    "editor.defaultFormatter": "hashicorp.terraform",
+    "editor.formatOnSave": true,
+    "editor.formatOnSaveMode": "file"
+  }
+}

--- a/kms-key/kms-aliases.tf
+++ b/kms-key/kms-aliases.tf
@@ -1,4 +1,4 @@
 resource "aws_kms_alias" "a" {
-  name          = "alias/${var.project}/${var.environment}/${var.alias}"
+  name          = replace("alias/${var.project}/${var.environment}/${var.alias}", "/[^a-zA-Z0-9:///_-]+/", "-")
   target_key_id = aws_kms_key.key.key_id
 }

--- a/s3-private/s3.tf
+++ b/s3-private/s3.tf
@@ -35,7 +35,7 @@ resource "aws_s3_bucket_cors_configuration" "main-bucket-cors-configuration" {
 resource "aws_s3_bucket_versioning" "main-bucket-versioning" {
   bucket = aws_s3_bucket.main.id
   versioning_configuration {
-    status = var.versioning
+    status = var.versioning ? "Enabled" : "Disabled"
   }
 }
 

--- a/s3-public/s3.tf
+++ b/s3-public/s3.tf
@@ -1,24 +1,34 @@
 resource "aws_s3_bucket" "main" {
   bucket = var.bucket_name
-  acl    = "public-read"
-
-  versioning {
-    enabled = var.versioning
-  }
-
-  # Move data to a cheaper storage class after a period of time
-  lifecycle_rule {
-    enabled = var.primary_storage_class_retention == 0 ? false : false
-
-    noncurrent_version_transition {
-      days          = var.primary_storage_class_retention == 0 ? 365 : var.primary_storage_class_retention
-      storage_class = "STANDARD_IA"
-    }
-  }
-
   tags = {
     Name        = var.bucket_name
     Project     = var.project
     Environment = var.environment
+  }
+}
+
+resource "aws_s3_bucket_versioning" "main-bucket-versioning" {
+  bucket = aws_s3_bucket.main.id
+  versioning_configuration {
+    status = var.versioning ? "Enabled" : "Disabled"
+  }
+}
+
+resource "aws_s3_bucket_acl" "main-bucket-data-acl" {
+  bucket = aws_s3_bucket.main.id
+  acl    = "public-read"
+}
+
+# Move data to a cheaper storage class after a period of time
+resource "aws_s3_bucket_lifecycle_configuration" "main-bucket-lifecycle-rule" {
+  bucket = aws_s3_bucket.main.id
+
+  rule {
+    id     = "primary-storage-class-retention"
+    status = var.primary_storage_class_retention == 0 ? "Disabled" : "Enabled"
+    noncurrent_version_transition {
+      noncurrent_days = var.primary_storage_class_retention == 0 ? 365 : var.primary_storage_class_retention
+      storage_class   = "STANDARD_IA"
+    }
   }
 }


### PR DESCRIPTION
### Motivations
Lot of syntax in the S3 library is deprecated. (Check [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket))
Replace the deprecated syntax to ensure smoother transition to the latest version


## for testing
closes #70
closes #69