### PR TITLE
[Chore] Use elasticache replication group instead of cluster

### DIFF
--- a/elasticache/README.md
+++ b/elasticache/README.md
@@ -22,6 +22,10 @@ module "elasticache" {
   node_type  = "cache.t3.micro"
   engine_version = "6.x"
   parameter_group_name = "default.redis6.x"
+  # Number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them.
+  # If the value of snapshot_retention_limit is set to zero (0), backups are turned off.
+  # Please note that setting a snapshot_retention_limit is not supported on cache.t1.micro cache nodes
+  snapshot_retention_limit = 0
 }
 ```
 

--- a/elasticache/README.md
+++ b/elasticache/README.md
@@ -21,6 +21,8 @@ module "elasticache" {
   node_count = 1
   node_type  = "cache.t3.micro"
   engine_version = "6.x"
+  # To enable cluster mode, use a parameter group that has cluster mode enabled.
+  # The default parameter groups provided by AWS end with ".cluster.on", for example default.redis6.x.cluster.on.
   parameter_group_name = "default.redis6.x"
   # Number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them.
   # If the value of snapshot_retention_limit is set to zero (0), backups are turned off.

--- a/elasticache/README.md
+++ b/elasticache/README.md
@@ -26,6 +26,10 @@ module "elasticache" {
   # If the value of snapshot_retention_limit is set to zero (0), backups are turned off.
   # Please note that setting a snapshot_retention_limit is not supported on cache.t1.micro cache nodes
   snapshot_retention_limit = 0
+
+  # Compulsory for Cluster Mode
+  num_node_groups = 2
+  replicas_per_node_group = 1
 }
 ```
 

--- a/elasticache/elasticache.tf
+++ b/elasticache/elasticache.tf
@@ -23,6 +23,10 @@ resource "aws_elasticache_replication_group" "main" {
     "${aws_security_group.main.id}",
   ]
 
+  # Cluster Mode
+  num_node_groups         = var.num_node_groups
+  replicas_per_node_group = var.replicas_per_node_group
+
   tags = {
     Project     = var.project
     Environment = var.environment

--- a/elasticache/elasticache.tf
+++ b/elasticache/elasticache.tf
@@ -10,6 +10,7 @@ resource "aws_elasticache_replication_group" "main" {
   subnet_group_name          = aws_elasticache_subnet_group.main.name
   at_rest_encryption_enabled = true
   kms_key_id                 = var.kms_key_arn
+  snapshot_retention_limit   = var.snapshot_retention_limit
   # When you change an attribute, such as engine_version,
   # by default the ElastiCache API applies it in the next maintenance window.
   # Because of this, Terraform may report a difference in its planning phase

--- a/elasticache/elasticache.tf
+++ b/elasticache/elasticache.tf
@@ -1,13 +1,15 @@
 resource "aws_elasticache_replication_group" "main" {
-  replication_group_id = "${var.project}-${var.environment}"
-  description          = "Collection of Redis cache clusters for ${var.project}-${var.environment}"
-  engine               = "redis"
-  node_type            = var.node_type
-  num_cache_clusters   = var.node_count
-  parameter_group_name = var.parameter_group_name
-  engine_version       = var.engine_version
-  port                 = 6379
-  subnet_group_name    = aws_elasticache_subnet_group.main.name
+  replication_group_id       = "${var.project}-${var.environment}"
+  description                = "Collection of Redis cache clusters for ${var.project}-${var.environment}"
+  engine                     = "redis"
+  node_type                  = var.node_type
+  num_cache_clusters         = var.node_count
+  parameter_group_name       = var.parameter_group_name
+  engine_version             = var.engine_version
+  port                       = 6379
+  subnet_group_name          = aws_elasticache_subnet_group.main.name
+  at_rest_encryption_enabled = true
+  kms_key_id                 = var.kms_key_arn
   # When you change an attribute, such as engine_version,
   # by default the ElastiCache API applies it in the next maintenance window.
   # Because of this, Terraform may report a difference in its planning phase

--- a/elasticache/elasticache.tf
+++ b/elasticache/elasticache.tf
@@ -1,15 +1,21 @@
-# Non encrypted basic cluster, for caching
-resource "aws_elasticache_cluster" "main" {
-  cluster_id           = "${var.project}-${var.environment}"
+resource "aws_elasticache_replication_group" "main" {
+  replication_group_id = "${var.project}-${var.environment}"
+  description          = "Collection of Redis cache clusters for ${var.project}-${var.environment}"
   engine               = "redis"
   node_type            = var.node_type
-  num_cache_nodes      = var.node_count
+  num_cache_clusters   = var.node_count
   parameter_group_name = var.parameter_group_name
   engine_version       = var.engine_version
   port                 = 6379
   subnet_group_name    = aws_elasticache_subnet_group.main.name
-  apply_immediately    = true
-
+  # When you change an attribute, such as engine_version,
+  # by default the ElastiCache API applies it in the next maintenance window.
+  # Because of this, Terraform may report a difference in its planning phase
+  # because the actual modification has not yet taken place.
+  # Set apply_immediately flag to true to instruct the service to apply the change immediately
+  # but will result in a brief downtime as servers reboots.
+  apply_immediately           = true
+  preferred_cache_cluster_azs = var.availability_zones
   security_group_ids = [
     "${aws_security_group.main.id}",
   ]

--- a/elasticache/elasticache.tf
+++ b/elasticache/elasticache.tf
@@ -29,6 +29,7 @@ resource "aws_elasticache_replication_group" "main" {
   lifecycle {
     ignore_changes = [
       engine_version,
+      num_cache_clusters
     ]
   }
 }

--- a/elasticache/outputs.tf
+++ b/elasticache/outputs.tf
@@ -1,4 +1,4 @@
 output "endpoint" {
-  description = "Elasticache cluster cache node address"
-  value       = aws_elasticache_cluster.main.cache_nodes[0].address
+  description = "The endpoint of the primary node in this node group (shard)"
+  value       = aws_elasticache_replication_group.main.primary_endpoint_address
 }

--- a/elasticache/variables.tf
+++ b/elasticache/variables.tf
@@ -22,3 +22,8 @@ variable "engine_version" {
   type    = string
   default = "6.x"
 }
+
+variable "snapshot_retention_limit" {
+  type    = number
+  default = 0
+}

--- a/elasticache/variables.tf
+++ b/elasticache/variables.tf
@@ -2,6 +2,7 @@ variable "project" {}
 variable "environment" {}
 variable "vpc_id" {}
 variable "vpc_cidr" {}
+variable "kms_key_arn" {}
 variable "subnet_ids" { type = list(string) }
 variable "availability_zones" { type = list(string) }
 

--- a/elasticache/variables.tf
+++ b/elasticache/variables.tf
@@ -27,3 +27,13 @@ variable "snapshot_retention_limit" {
   type    = number
   default = 0
 }
+
+variable "replicas_per_node_group" {
+  default     = ""
+  description = "Replicas per Shard."
+}
+
+variable "num_node_groups" {
+  default     = ""
+  description = "Number of Shards (nodes)."
+}


### PR DESCRIPTION
### Summary

In the terraform documentations, it is stated that the value for `num_cache_nodes` for Redis must be 1, which prohibited us for creating more redis cache nodes.
This PR uses replication group which is the AWS [recommended way](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Replication.CreatingRepGroup.html) to manage replica nodes of Redis 

Please be noted that this setup disable cluster mode. 