### PR TITLE
Execution role is based on region

### DIFF
--- a/ecs/execution-role.tf
+++ b/ecs/execution-role.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "ecs-task-execution" {
-  name = "ecs-task-execution-${var.project}-${var.environment}"
+  name = "ecs-task-execution-${var.project}-${var.environment}${var.regional ? "-${var.region}" : ""}"
   managed_policy_arns = [
     "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -1,7 +1,13 @@
 variable "environment" {}
 variable "project" {}
 variable "vpc_id" {}
+
+# Regional allows clusters with the same name to be in multiple regions
 variable "region" { default = "eu-central-1" }
+variable "regional" {
+  default = false
+  type    = bool
+}
 
 variable "allow_internal_traffic_to_ports" {
   type    = list(string)


### PR DESCRIPTION
When spreading out of more than a single region the IAM role name needs to be unique.

By default, this will be backwards compatible. I would prefer for it to be regional by default, but this would require updating all previous projects using this.