### PR TITLE
ECS: Use local.name consistently

### DIFF
--- a/ecs/cloudwatch.tf
+++ b/ecs/cloudwatch.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_dashboard" "main" {
-  dashboard_name = "${var.project}-${var.environment}-ecs"
+  dashboard_name = "${local.name}-ecs"
 
   dashboard_body = <<EOF
 {
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_dashboard" "main" {
       "type": "metric",
       "properties": {
         "metrics": [
-          [ "ECS/ContainerInsights", "CpuUtilized", "ServiceName", "web", "ClusterName", "${var.project}-${var.environment}" ]
+          [ "ECS/ContainerInsights", "CpuUtilized", "ServiceName", "web", "ClusterName", "${local.name}" ]
         ],
         "view": "timeSeries",
         "stacked": false,
@@ -40,7 +40,7 @@ resource "aws_cloudwatch_dashboard" "main" {
       "properties": {
         "metrics": [
           [ { "expression": "100*(m1/m2)", "label": "MemoryUsage", "id": "e1", "region": "${var.region}", "yAxis": "left" } ],
-          [ "ECS/ContainerInsights", "MemoryUtilized", "ServiceName", "web", "ClusterName", "${var.project}-${var.environment}", { "id": "m1", "visible": false } ],
+          [ "ECS/ContainerInsights", "MemoryUtilized", "ServiceName", "web", "ClusterName", "${local.name}", { "id": "m1", "visible": false } ],
           [ ".", "MemoryReserved", ".", ".", ".", ".", { "id": "m2", "visible": false } ]
         ],
         "view": "timeSeries",

--- a/ecs/ecs-cluster.tf
+++ b/ecs/ecs-cluster.tf
@@ -1,5 +1,5 @@
 resource "aws_ecs_cluster" "main" {
-  name = "${var.project}-${var.environment}"
+  name = local.name
 
   setting {
     name  = "containerInsights"
@@ -7,7 +7,7 @@ resource "aws_ecs_cluster" "main" {
   }
 
   tags = {
-    Name        = "${var.project}-${var.environment}"
+    Name        = local.name
     Project     = var.project
     Environment = var.environment
   }

--- a/ecs/execution-role.tf
+++ b/ecs/execution-role.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "ecs-task-execution" {
-  name = "ecs-task-execution-${var.project}-${var.environment}${var.regional ? "-${var.region}" : ""}"
+  name = "ecs-task-execution-${local.name}${var.regional ? "-${var.region}" : ""}"
   managed_policy_arns = [
     "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",

--- a/ecs/iam.tf
+++ b/ecs/iam.tf
@@ -2,12 +2,12 @@
 
 # Grant access to list and describe clusters
 resource "aws_iam_group" "ecs-view" {
-  name = "${var.project}-${var.environment}-ecs-view"
+  name = "${local.name}-ecs-view"
 }
 resource "aws_iam_policy" "ecs-view" {
-  name        = "${var.project}-${var.environment}-ecs-view"
+  name        = "${local.name}-ecs-view"
   path        = "/"
-  description = "Allow viewing ECS clusters for ${var.project} ${var.environment}"
+  description = "Allow viewing ECS clusters for ${local.name}"
 
   policy = <<EOF
 {
@@ -63,12 +63,12 @@ resource "aws_iam_group_policy_attachment" "ecs-view" {
 
 # Grant access to console
 resource "aws_iam_group" "ecs-console" {
-  name = "${var.project}-${var.environment}-ecs-console"
+  name = "${local.name}-ecs-console"
 }
 resource "aws_iam_policy" "ecs-console" {
-  name        = "${var.project}-${var.environment}-ecs-console"
+  name        = "${local.name}-ecs-console"
   path        = "/"
-  description = "Allow console into ECS clusters for ${var.project} ${var.environment}"
+  description = "Allow console into ECS clusters for ${local.name}"
 
   policy = <<EOF
 {

--- a/ecs/nlb.tf
+++ b/ecs/nlb.tf
@@ -5,7 +5,7 @@ resource "aws_lb" "nlb" {
   subnets            = var.subnet_public_ids
   idle_timeout       = 600
   tags = {
-    Name        = "${var.project}-${var.environment}-nlb"
+    Name        = "${local.name}-nlb"
     Project     = var.project
     Environment = var.environment
   }
@@ -14,7 +14,7 @@ resource "aws_lb" "nlb" {
 # Bastion is allowed, only from some IPs
 resource "aws_lb_target_group" "ssh" {
   count       = length(aws_lb.nlb)
-  name        = "${var.project}-${var.environment}-ssh"
+  name        = "${local.name}-ssh"
   port        = 22
   protocol    = "TCP"
   vpc_id      = var.vpc_id

--- a/ecs/security-groups.tf
+++ b/ecs/security-groups.tf
@@ -1,9 +1,9 @@
 # Load balancer to receive all incoming traffic infront of the cluster
 resource "aws_security_group" "alb" {
   vpc_id = var.vpc_id
-  name   = "${var.project}-${var.environment}-alb"
+  name   = "${local.name}-alb"
   tags = {
-    Name        = "${var.project}-${var.environment}-alb"
+    Name        = "${local.name}-alb"
     Description = "Incoming internet traffic to Load Balancer"
     Project     = var.project
     Environment = var.environment
@@ -40,9 +40,9 @@ resource "aws_security_group_rule" "lb-https" {
 # ECS cluster should only be able to receive traffic to container ports from the ALB
 resource "aws_security_group" "ecs" {
   vpc_id = var.vpc_id
-  name   = "${var.project}-${var.environment}-ecs"
+  name   = "${local.name}-ecs"
   tags = {
-    Name        = "${var.project}-${var.environment}-ecs"
+    Name        = "${local.name}-ecs"
     Description = "Internal ECS communication"
     Project     = var.project
     Environment = var.environment

--- a/ecs/target-groups.tf
+++ b/ecs/target-groups.tf
@@ -1,6 +1,6 @@
 # Main entrypoint for the cluster applications
 resource "aws_alb_target_group" "ecs" {
-  name        = "${var.project}-${var.environment}-ecs"
+  name        = "${local.name}-ecs"
   port        = 3000
   protocol    = "HTTP"
   vpc_id      = var.vpc_id


### PR DESCRIPTION
Some resource get recreated due to the description changing, but this is safe.

This is mainly to prepare for fully regional clusters and custom name overrides.