### PR TITLE
ECS: Custom cluster name

### DIFF
--- a/ecs/execution-role.tf
+++ b/ecs/execution-role.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "ecs-task-execution" {
-  name = "ecs-task-execution-${local.name}${var.regional ? "-${var.region}" : ""}"
+  name = "ecs-task-execution-${local.name}"
   managed_policy_arns = [
     "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",

--- a/ecs/locals.tf
+++ b/ecs/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  name = "${var.project}-${var.environment}"
+  name = var.name != null ? var.name : "${var.project}-${var.environment}${var.regional ? "-${var.region}" : ""}"
 }

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -4,8 +4,9 @@ variable "vpc_id" {}
 
 # A custom name overrides the default {project}-{environment} convention
 variable "name" {
-  type    = string
-  default = null
+  type        = string
+  description = "Custom name for the cluster. Must be unique per account if deploying to multiple regions."
+  default     = null
 }
 
 # Regional allows clusters with the same name to be in multiple regions

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -2,6 +2,12 @@ variable "environment" {}
 variable "project" {}
 variable "vpc_id" {}
 
+# A custom name overrides the default {project}-{environment} convention
+variable "name" {
+  type    = string
+  default = null
+}
+
 # Regional allows clusters with the same name to be in multiple regions
 variable "region" { default = "eu-central-1" }
 variable "regional" {


### PR DESCRIPTION
Fully backwards compatible without any changes. Default name is `${var.project}-${var.environment}`