### PR TITLE
RDS as read replica, Stack with VPC Peering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: validate
         run: |
           cd ${{ matrix.module }}
+          # the stack/app module must have a provider block because the sub-module requires a non-standard "provider
+          # see: https://github.com/hashicorp/terraform/issues/28490
+          if [[ "${{ matrix.module }}" == "stack/app" ]]; then echo "provider \"aws\" { alias = \"peer\" }" >> vpc-peering.tf; fi
           terraform validate
 
       - name: fmt -check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           # the stack/app module must have a provider block because the sub-module "vpc-peering" requires a non-standard "provider
           # see: https://github.com/hashicorp/terraform/issues/28490
           if [[ "${{ matrix.module }}" == "stack/app" ]]; then echo "provider \"aws\" { alias = \"peer\" }" >> vpc-peering.tf; fi
-          if [[ "${{ matrix.module }}" == "stack/app" ]]; then echo "provider \"aws\" { alias = \"peer\" }" >> main.tf; fi
+          if [[ "${{ matrix.module }}" == "vpc-peering" ]]; then echo "provider \"aws\" { alias = \"peer\" }" >> main.tf; fi
           terraform validate
 
       - name: fmt -check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - stack/app
           - stack/setup
           - vpc
+          - vpc-peering
           # - vpn # TODO: Figure out private module access
       fail-fast: false
     runs-on: ubuntu-latest
@@ -41,9 +42,10 @@ jobs:
       - name: validate
         run: |
           cd ${{ matrix.module }}
-          # the stack/app module must have a provider block because the sub-module requires a non-standard "provider
+          # the stack/app module must have a provider block because the sub-module "vpc-peering" requires a non-standard "provider
           # see: https://github.com/hashicorp/terraform/issues/28490
           if [[ "${{ matrix.module }}" == "stack/app" ]]; then echo "provider \"aws\" { alias = \"peer\" }" >> vpc-peering.tf; fi
+          if [[ "${{ matrix.module }}" == "stack/app" ]]; then echo "provider \"aws\" { alias = \"peer\" }" >> main.tf; fi
           terraform validate
 
       - name: fmt -check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - iam/iam-for-humans
           - iam/iam-policy-for-taggable-resources
           - kms-key
+          - kms-key-replica
           - nat
           - rds
           - s3-private

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project does not follow SemVer, since modules are independent of each other
 
 ## [unreleased]
 
+## KMS Key Replica
+- new module that allows to create a replica of a KMS key in another region, [#97](https://github.com/dbl-works/
+
 ## RDS
 - added the option to create a read-replica, [#97](https://github.com/dbl-works/terraform/pull/97)
 - allow to create unique names across regions by setting `regional`, [#97](https://github.com/dbl-works/terraform/pull/97)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project does not follow SemVer, since modules are independent of each other
 
 ## RDS
 - added the option to create a read-replica, [#97](https://github.com/dbl-works/terraform/pull/97)
+- allow to create unique names across regions by setting `regional`, [#97](https://github.com/dbl-works/terraform/pull/97)
 
 ## VPC-Peering
 - added a new module `vpc-peering` to create a VPC Peering Resource, [#97](https://github.com/dbl-works/terraform/pull/97)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project does not follow SemVer, since modules are independent of each other
 
 ## Stack & Cloudflare
 - fixed issues when setting up a bastion, [#93](https://github.com/dbl-works/terraform/pull/93)
+- added the option to launch a stack with a RDS read-replica, [#96](https://github.com/dbl-works/terraform/pull/96)
 
 
 ## [v2022.06.23]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project does not follow SemVer, since modules are independent of each other
 
 ## [unreleased]
 
+## VPC-Peering
+- added a new module `vpc-peering` to create a VPC Peering Resource, [#96](https://github.com/dbl-works/terraform/pull/96)
+
 ## Stack & Cloudflare
 - fixed issues when setting up a bastion, [#93](https://github.com/dbl-works/terraform/pull/93)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ This project does not follow SemVer, since modules are independent of each other
 ## [unreleased]
 
 ## RDS
-- added the option to create a read-replica, [#96](https://github.com/dbl-works/terraform/pull/96)
+- added the option to create a read-replica, [#97](https://github.com/dbl-works/terraform/pull/97)
 
 ## VPC-Peering
-- added a new module `vpc-peering` to create a VPC Peering Resource, [#96](https://github.com/dbl-works/terraform/pull/96)
+- added a new module `vpc-peering` to create a VPC Peering Resource, [#97](https://github.com/dbl-works/terraform/pull/97)
 
 ## Stack & Cloudflare
 - fixed issues when setting up a bastion, [#93](https://github.com/dbl-works/terraform/pull/93)
-- added the option to launch a stack with a RDS read-replica, [#96](https://github.com/dbl-works/terraform/pull/96)
+- added the option to launch a stack with a RDS read-replica, [#97](https://github.com/dbl-works/terraform/pull/97)
 
 
 ## [v2022.06.23]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project does not follow SemVer, since modules are independent of each other
 
 ## [unreleased]
 
+## RDS
+- added the option to create a read-replica, [#96](https://github.com/dbl-works/terraform/pull/96)
+
 ## VPC-Peering
 - added a new module `vpc-peering` to create a VPC Peering Resource, [#96](https://github.com/dbl-works/terraform/pull/96)
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ We create modules here for re-use between projects.
 - [secrets](secrets/README.md) - Used for creating a new secret.
 - [stack](stack/README.md) - Creates all resources required to launch and entire application
 - [vpc](vpc/README.md) - Creates a VPC in AWS account. Also generates a group fo public and private submodules.
+- [vpc-peering](vpc-peering/README.md) - Creates a VPC Peering Resource.
 - [vpn](vpn/README.md) - Launches an isolated Outline VPN inside a new VPC.
 
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ We create modules here for re-use between projects.
 - [ecs](ecs/README.md) - Compute cluster for running docker containers.
 - [elasticache](elasticache/README.md) - elasticache cluster based on Redis.
 - [kms-key](kms-key/README.md) - Encryption keys for securing various AWS resources.
+- [kms-key-replica](kms-key-replica/README.md) - KMS Key replica for cross-regional access to encryption keys.
 - [nat](nat/README.md) - A reopsitory for setting up a network address translation (NAT).
 - [rds](rds/README.md) - Used for creating and configuring databases and their networking.
 - [s3-private](s3-private/README.md) - Private, encrypted S3 bucket with versioning.

--- a/kms-key-replica/README.md
+++ b/kms-key-replica/README.md
@@ -1,0 +1,19 @@
+# Terraform Module: kms-key-replica
+
+Replica of a KMS key for multi-regional KMS keys. E.g. if you have read-replicas of an RDS instance in multiple geo-regions that use an KMS key for encryption.
+
+
+
+## Usage
+
+```terraform
+module "kms-key-replica" {
+  source = "github.com/dbl-works/terraform//kms-key-replica?ref=v2021.07.01"
+
+  # Required
+  master_kms_key_arn = "arn:aws:kms:${var.master_region}:${var.acccount_id}:key/mrk-XXX" # NOTE: multi region keys start with "mrk"
+  environment        = "staging"
+  project            = "someproject"
+  alias              = "rds"
+}
+```

--- a/kms-key-replica/main.tf
+++ b/kms-key-replica/main.tf
@@ -1,0 +1,19 @@
+# https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-auth.html
+# if we create a RDS read-replica in a different region, we must pass the KMS key ARN to the replica
+# so that the replica can read an encrypted master DB. KMS keys by default are only accessible in their
+# region, hence we must create a replica of the RDS key.
+resource "aws_kms_replica_key" "replica" {
+  description             = "Multi-Region replica key"
+  deletion_window_in_days = 7
+  primary_key_arn         = var.master_kms_key_arn
+
+  tags = {
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+resource "aws_kms_alias" "a" {
+  name          = replace("alias/${var.project}/${var.environment}/${var.alias}", "/[^a-zA-Z0-9:///_-]+/", "-")
+  target_key_id = aws_kms_replica_key.key_id
+}

--- a/kms-key-replica/main.tf
+++ b/kms-key-replica/main.tf
@@ -15,5 +15,5 @@ resource "aws_kms_replica_key" "replica" {
 
 resource "aws_kms_alias" "a" {
   name          = replace("alias/${var.project}/${var.environment}/${var.alias}", "/[^a-zA-Z0-9:///_-]+/", "-")
-  target_key_id = aws_kms_replica_key.key_id
+  target_key_id = aws_kms_replica_key.replica.key_id
 }

--- a/kms-key-replica/outputs.tf
+++ b/kms-key-replica/outputs.tf
@@ -1,0 +1,7 @@
+output "id" {
+  value = aws_kms_replica_key.replica.id
+}
+
+output "arn" {
+  value = aws_kms_replica_key.replica.arn
+}

--- a/kms-key-replica/variables.tf
+++ b/kms-key-replica/variables.tf
@@ -1,0 +1,15 @@
+variable "project" {
+  type = string
+}
+
+variable "alias" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "master_kms_key_arn" {
+  type = string
+}

--- a/kms-key-replica/versions.tf
+++ b/kms-key-replica/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = ">= 4.0"
+      configuration_aliases = [aws.peer]
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/kms-key-replica/versions.tf
+++ b/kms-key-replica/versions.tf
@@ -1,9 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source                = "hashicorp/aws"
-      version               = ">= 4.0"
-      configuration_aliases = [aws.peer]
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
     }
   }
   required_version = ">= 1.0"

--- a/kms-key/README.md
+++ b/kms-key/README.md
@@ -18,5 +18,6 @@ module "kms-key" {
 
   # Optional
   deletion_window_in_days = 30
+  multi_region            = false # use with caution. E.g. when having a cross region RDS read replica
 }
 ```

--- a/kms-key/kms-key.tf
+++ b/kms-key/kms-key.tf
@@ -2,6 +2,8 @@ resource "aws_kms_key" "key" {
   description             = var.description
   deletion_window_in_days = var.deletion_window_in_days
   enable_key_rotation     = true
+  multi_region            = var.multi_region
+
   tags = {
     Project     = var.project
     Environment = var.environment

--- a/kms-key/variables.tf
+++ b/kms-key/variables.tf
@@ -2,5 +2,9 @@ variable "alias" {} # will be stored as alias/{project}/{environment}/{alias}
 variable "environment" {}
 variable "description" {}
 variable "project" {}
+variable "multi_region" {
+  type    = bool
+  default = false
+}
 
 variable "deletion_window_in_days" { default = 30 }

--- a/rds/README.md
+++ b/rds/README.md
@@ -5,6 +5,8 @@ Used for creating and configuring databases and their networking.
 Will create an initial database named `{project}_{environment}`.
 
 
+:warning: If you create a read replica in another VPC you need a [VPC-Peering-Resource](vpc-peering/README.md).
+
 
 ## Usage
 
@@ -28,6 +30,10 @@ module "db" {
   publicly_accessible = false
   allocated_storage   = 100
   multi_az            = false
+
+  # when creating a read-replica
+  master_db_instance_arn = null  # ARN of the master database
+  is_read_replica        = false # if true, this will be a read-replica
 }
 ```
 

--- a/rds/README.md
+++ b/rds/README.md
@@ -30,6 +30,8 @@ module "db" {
   publicly_accessible = false
   allocated_storage   = 100
   multi_az            = false
+  regional            = false # set to `true` to append region to name, unless name given
+  name                = null # defaults to "${var.project}-${var.environment}", may need to be unique per region
 
   # when creating a read-replica
   master_db_instance_arn = null  # ARN of the master database

--- a/rds/outputs.tf
+++ b/rds/outputs.tf
@@ -2,3 +2,7 @@
 output "database_url" {
   value = aws_db_instance.main.endpoint
 }
+
+output "database_arn" {
+  value = aws_db_instance.main.arn
+}

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -45,8 +45,7 @@ resource "aws_db_instance" "main" {
   lifecycle {
     ignore_changes = [
       engine_version, # AWS will auto-update minor version changes
-      latest_restorable_time,
-      db_name, # if you didn't use this before it would re-create your RDS instance
+      db_name,        # if you didn't use this before it would re-create your RDS instance
     ]
   }
 }

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -5,11 +5,11 @@ resource "aws_db_instance" "main" {
   engine                              = "postgres"
   engine_version                      = var.engine_version
   instance_class                      = var.instance_class
-  identifier                          = "${var.project}-${var.environment}"
+  identifier                          = "${var.project}-${var.environment}${var.is_read_replica ? "-read-replica" : ""}"
   db_name                             = "${var.project}_${var.environment}" # name of the initial database
   skip_final_snapshot                 = true
-  username                            = var.username
-  password                            = var.password
+  username                            = var.is_read_replica ? null : var.username # credentials of the master DB are used
+  password                            = var.is_read_replica ? null : var.password # credentials of the master DB are used
   iam_database_authentication_enabled = true
   parameter_group_name                = aws_db_parameter_group.postgres13.name
   apply_immediately                   = true
@@ -19,7 +19,7 @@ resource "aws_db_instance" "main" {
   vpc_security_group_ids = [
     aws_security_group.db.id,
   ]
-  backup_retention_period         = 7
+  backup_retention_period         = var.is_read_replica ? 0 : 7
   storage_encrypted               = true
   kms_key_id                      = var.kms_key_arn
   monitoring_interval             = 5
@@ -30,6 +30,10 @@ resource "aws_db_instance" "main" {
     "postgresql",
     "upgrade",
   ]
+
+  # the "identifier" may be used when the replica is in the same region as the master
+  # otherwise, the ARN must be used.
+  replicate_source_db = var.master_db_instance_arn
 
   tags = {
     Name        = "${var.project}-${var.environment}"

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -2,11 +2,11 @@ resource "aws_db_instance" "main" {
   db_subnet_group_name                = aws_db_subnet_group.main.name
   allocated_storage                   = var.allocated_storage
   storage_type                        = "gp2"
-  engine                              = "postgres"
-  engine_version                      = var.engine_version
+  engine                              = var.is_read_replica ? null : "postgres"
+  engine_version                      = var.is_read_replica ? null : var.engine_version
   instance_class                      = var.instance_class
   identifier                          = "${var.project}-${var.environment}${var.is_read_replica ? "-read-replica" : ""}"
-  db_name                             = "${var.project}_${var.environment}" # name of the initial database
+  db_name                             = var.is_read_replica ? null : "${var.project}_${var.environment}" # name of the initial database
   skip_final_snapshot                 = true
   username                            = var.is_read_replica ? null : var.username # credentials of the master DB are used
   password                            = var.is_read_replica ? null : var.password # credentials of the master DB are used

--- a/rds/role-enhanced-monitoring.tf
+++ b/rds/role-enhanced-monitoring.tf
@@ -1,6 +1,6 @@
 # RDS Enhanced Monitoring requires a specific role + KMS key to operate
 resource "aws_iam_role" "rds-enhanced-monitoring" {
-  name               = "rds-enhanced-monitoring-${var.project}-${var.environment}"
+  name               = "rds-enhanced-monitoring-${local.name}"
   assume_role_policy = data.aws_iam_policy_document.rds_enhanced_monitoring.json
 
   tags = {

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -40,3 +40,15 @@ variable "allow_from_security_groups" {
   description = "Security groups which RDS allow traffics from"
   default     = []
 }
+
+
+## Read replica mode
+variable "master_db_instance_arn" {
+  default = null
+  type    = string
+}
+
+variable "is_read_replica" {
+  type    = bool
+  default = false
+}

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -52,3 +52,15 @@ variable "is_read_replica" {
   type    = bool
   default = false
 }
+
+variable "regional" {
+  default = false
+  type    = bool
+}
+
+# A custom name overrides the default {project}-{environment} convention
+variable "name" {
+  type        = string
+  description = "Custom name for resources. Must be unique per account if deploying to multiple regions."
+  default     = null
+}

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -100,6 +100,8 @@ module "stack" {
   # appends region to the name (usually ${project}-${environment}) for globally unique names
   regional = true
 
+  ecs_name = null # custom name when convention exceeds 32 chars
+
   # Elasticache
   elasticache_node_type                     = "cache.t3.micro"
   elasticache_replicas_per_node_group       = 1

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -164,7 +164,6 @@ output "accept_status-accepter" {
 output "rds_kms_key_arn" {
   value = module.stack.rds_kms_key_arn
 }
-
 ```
 
 

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -82,12 +82,13 @@ module "stack" {
   ## Will create a VPC Peering Resource to allow connections to the master DB;
   ## This stack is the requester, the stack with the main DB is the accepter.
   ## The master-DB KMS key arn must be passed to allow decrypting the master DB.
-  rds_is_read_replica        = false
-  rds_master_db_instance_arn = null
-  rds_master_db_region       = null
-  rds_master_db_vpc_id       = null
-  rds_master_db_kms_key_arn  = null
-  rds_name                   = null # unique name, shouldn't be necessary if "regional" is set to true
+  rds_is_read_replica            = false
+  rds_master_db_instance_arn     = null
+  rds_master_db_region           = null
+  rds_master_db_vpc_id           = null
+  rds_master_db_kms_key_arn      = null
+  rds_name                       = null # unique name, shouldn't be necessary if "regional" is set to true
+  rds_cross_region_kms_keys_arns = [] # pass the RDS KMS key here to allow the replica to read the encrypted master
 
   # ECS
   allow_internal_traffic_to_ports = []

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -87,6 +87,7 @@ module "stack" {
   rds_master_db_region       = null
   rds_master_db_vpc_id       = null
   rds_master_db_kms_key_arn  = null
+  rds_name                   = null # unique name, shouldn't be necessary if "regional" is set to true
 
   # ECS
   allow_internal_traffic_to_ports = []

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -80,10 +80,12 @@ module "stack" {
   ## another region. Otherwise, the instance-identifier may be used.
   ## Will create a VPC Peering Resource to allow connections to the master DB;
   ## This stack is the requester, the stack with the main DB is the accepter.
+  ## The master-DB KMS key arn must be passed to allow decrypting the master DB.
   rds_is_read_replica        = false
   rds_master_db_instance_arn = null
   rds_master_db_region       = null
   rds_master_db_vpc_id       = null
+  rds_master_db_kms_key_arn  = null
 
   # ECS
   allow_internal_traffic_to_ports = []

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -89,6 +89,7 @@ module "stack" {
   rds_master_db_kms_key_arn      = null
   rds_name                       = null # unique name, shouldn't be necessary if "regional" is set to true
   rds_cross_region_kms_keys_arns = [] # pass the RDS KMS key here to allow the replica to read the encrypted master
+  rds_multi_region_kms_key       = false # set to true for the MASTER stack, so that replicas can create a replica of the key
 
   # ECS
   allow_internal_traffic_to_ports = []

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -89,14 +89,16 @@ module "stack" {
 
   # ECS
   allow_internal_traffic_to_ports = []
-  allowlisted_ssh_ips = []
-  grant_read_access_to_s3_arns = []
-  grant_write_access_to_s3_arns = []
-  grant_read_access_to_sqs_arns  = []
-  grant_write_access_to_sqs_arns = []
-  ecs_custom_policies = []
+  allowlisted_ssh_ips             = []
+  grant_read_access_to_s3_arns    = []
+  grant_write_access_to_s3_arns   = []
+  grant_read_access_to_sqs_arns   = []
+  grant_write_access_to_sqs_arns  = []
+  ecs_custom_policies             = []
   # This is only needed when we want to add additional secrets to the ECS
   secret_arns = []
+  # appends region to the name (usually ${project}-${environment}) for globally unique names
+  regional = true
 
   # Elasticache
   elasticache_node_type                     = "cache.t3.micro"

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -41,7 +41,8 @@ module "stack" {
   ]
 
   # Optional
-  region     = "eu-central-1"
+  region          = "eu-central-1"
+  skip_cloudflare = false
 
   # S3 Private
   private_buckets_list = [

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -82,14 +82,13 @@ module "stack" {
   ## Will create a VPC Peering Resource to allow connections to the master DB;
   ## This stack is the requester, the stack with the main DB is the accepter.
   ## The master-DB KMS key arn must be passed to allow decrypting the master DB.
-  rds_is_read_replica            = false
-  rds_master_db_instance_arn     = null
-  rds_master_db_region           = null
-  rds_master_db_vpc_id           = null
-  rds_master_db_kms_key_arn      = null
-  rds_name                       = null # unique name, shouldn't be necessary if "regional" is set to true
-  rds_cross_region_kms_keys_arns = [] # pass the RDS KMS key here to allow the replica to read the encrypted master
-  rds_multi_region_kms_key       = false # set to true for the MASTER stack, so that replicas can create a replica of the key
+  rds_is_read_replica        = false
+  rds_master_db_instance_arn = null
+  rds_master_db_region       = null
+  rds_master_db_vpc_id       = null
+  rds_master_db_kms_key_arn  = null
+  rds_name                   = null # unique name, shouldn't be necessary if "regional" is set to true
+  rds_multi_region_kms_key   = false # set to true for the MASTER stack, so that replicas can create a replica of the key
 
   # ECS
   allow_internal_traffic_to_ports = []

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -75,6 +75,16 @@ module "stack" {
   rds_engine_version     = "13"
   rds_allocated_storage  = 100
 
+  ## set these, if you want to create a read-replica instead of a master DB
+  ## the master-instance-arn MUST be the ARN of the DB, if the master DB is in
+  ## another region. Otherwise, the instance-identifier may be used.
+  ## Will create a VPC Peering Resource to allow connections to the master DB;
+  ## This stack is the requester, the stack with the main DB is the accepter.
+  rds_is_read_replica        = false
+  rds_master_db_instance_arn = null
+  rds_master_db_region       = null
+  rds_master_db_vpc_id       = null
+
   # ECS
   allow_internal_traffic_to_ports = []
   allowlisted_ssh_ips = []

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -151,6 +151,20 @@ output "nlb_target_group_ecs_arn" {
   value = module.stack.nlb_target_group_ecs_arn
 }
 
+
+# When launching a stack with a read replica
+output "accept_status-requester" {
+  value = module.stack.accept_status-requester
+}
+
+output "accept_status-accepter" {
+  value = module.stack.accept_status-accepter
+}
+
+output "rds_kms_key_arn" {
+  value = module.stack.rds_kms_key_arn
+}
+
 ```
 
 

--- a/stack/app/cloudflare.tf
+++ b/stack/app/cloudflare.tf
@@ -1,5 +1,6 @@
 module "cloudflare" {
   source = "../../cloudflare"
+  count  = var.rds_is_read_replica ? 0 : 1
 
   depends_on = [
     module.ecs,

--- a/stack/app/cloudflare.tf
+++ b/stack/app/cloudflare.tf
@@ -1,6 +1,6 @@
 module "cloudflare" {
   source = "../../cloudflare"
-  count  = var.rds_is_read_replica ? 0 : 1
+  count  = var.skip_cloudflare ? 0 : 1
 
   depends_on = [
     module.ecs,

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -23,6 +23,7 @@ module "ecs" {
   # optional
   health_check_path = var.health_check_path
   certificate_arn   = data.aws_acm_certificate.default.arn
+  regional          = var.regional
 
   allow_internal_traffic_to_ports = var.allow_internal_traffic_to_ports
 

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -24,6 +24,7 @@ module "ecs" {
   health_check_path = var.health_check_path
   certificate_arn   = data.aws_acm_certificate.default.arn
   regional          = var.regional
+  name              = var.ecs_name # custom name when convention exceeds 32 chars
 
   allow_internal_traffic_to_ports = var.allow_internal_traffic_to_ports
 

--- a/stack/app/outputs.tf
+++ b/stack/app/outputs.tf
@@ -37,11 +37,11 @@ output "nlb_target_group_ecs_arn" {
 
 # When launching a stack with a read replica
 output "accept_status-requester" {
-  value = var.rds_is_read_replica ? module.vpc-peering.accept_status-requester : "VPC peering not enabled."
+  value = var.rds_is_read_replica ? join("", module.vpc-peering.*.accept_status-requester) : "VPC peering not enabled."
 }
 
 output "accept_status-accepter" {
-  value = var.rds_is_read_replica ? module.vpc-peering.accept_status-accepter : "VPC peering not enabled."
+  value = var.rds_is_read_replica ? join("", module.vpc-peering.*.accept_status-accepter) : "VPC peering not enabled."
 }
 
 output "rds_kms_key_arn" {

--- a/stack/app/outputs.tf
+++ b/stack/app/outputs.tf
@@ -2,6 +2,10 @@ output "database_url" {
   value = module.rds.database_url
 }
 
+output "database_arn" {
+  value = module.rds.database_arn
+}
+
 output "redis_url" {
   value = module.elasticache.endpoint
 }

--- a/stack/app/outputs.tf
+++ b/stack/app/outputs.tf
@@ -35,11 +35,15 @@ output "nlb_target_group_ecs_arn" {
 }
 
 
-# VPC Peering
+# When launching a stack with a read replica
 output "accept_status-requester" {
   value = var.rds_is_read_replica ? module.vpc-peering.accept_status-requester : "VPC peering not enabled."
 }
 
 output "accept_status-accepter" {
   value = var.rds_is_read_replica ? module.vpc-peering.accept_status-accepter : "VPC peering not enabled."
+}
+
+output "rds_kms_key_arn" {
+  value = var.rds_master_db_kms_key_arn == null ? module.rds-kms-key[0].arn : "KMS ARN only printed for the master DB to be passed to each replica."
 }

--- a/stack/app/outputs.tf
+++ b/stack/app/outputs.tf
@@ -33,3 +33,13 @@ output "alb_target_group_ecs_arn" {
 output "nlb_target_group_ecs_arn" {
   value = module.ecs.nlb_target_group_ecs_arn
 }
+
+
+# VPC Peering
+output "accept_status-requester" {
+  value = var.rds_is_read_replica ? module.vpc-peering.accept_status-requester : "VPC peering not enabled."
+}
+
+output "accept_status-accepter" {
+  value = var.rds_is_read_replica ? module.vpc-peering.accept_status-accepter : "VPC peering not enabled."
+}

--- a/stack/app/outputs.tf
+++ b/stack/app/outputs.tf
@@ -45,5 +45,5 @@ output "accept_status-accepter" {
 }
 
 output "rds_kms_key_arn" {
-  value = var.rds_master_db_kms_key_arn == null ? module.rds-kms-key[0].arn : "KMS ARN only printed for the master DB to be passed to each replica."
+  value = var.rds_master_db_kms_key_arn == null ? join("", module.rds-kms-key.*.arn) : "KMS ARN only printed for the master DB to be passed to each replica."
 }

--- a/stack/app/rds.tf
+++ b/stack/app/rds.tf
@@ -33,4 +33,6 @@ module "rds" {
   multi_az               = var.environment == "production"
   master_db_instance_arn = var.rds_master_db_instance_arn
   is_read_replica        = var.rds_is_read_replica
+  regional               = var.regional
+  name                   = var.rds_name
 }

--- a/stack/app/rds.tf
+++ b/stack/app/rds.tf
@@ -1,5 +1,6 @@
 module "rds-kms-key" {
   source = "../../kms-key"
+  count  = var.rds_master_db_kms_key_arn == null ? 1 : 0
 
   # Required
   environment = var.environment
@@ -20,7 +21,7 @@ module "rds" {
   region                     = var.region
   vpc_id                     = module.vpc.id
   password                   = local.credentials.db_root_password
-  kms_key_arn                = module.rds-kms-key.arn
+  kms_key_arn                = coalesce(var.rds_master_db_kms_key_arn, module.rds-kms-key.arn)
   subnet_ids                 = module.vpc.subnet_private_ids
   allow_from_security_groups = [module.ecs.ecs_security_group_id]
 

--- a/stack/app/rds.tf
+++ b/stack/app/rds.tf
@@ -6,7 +6,7 @@ module "rds-kms-key" {
   environment = var.environment
   project     = var.project
   alias       = "rds"
-  description = "kms key for ${var.project} RDS"
+  description = "KMS key for ${var.project}-${var.environment} RDS."
 
   # Optional
   deletion_window_in_days = var.kms_deletion_window_in_days

--- a/stack/app/rds.tf
+++ b/stack/app/rds.tf
@@ -25,9 +25,11 @@ module "rds" {
   allow_from_security_groups = [module.ecs.ecs_security_group_id]
 
   # optional
-  username          = local.credentials.db_username
-  instance_class    = var.rds_instance_class
-  engine_version    = var.rds_engine_version
-  allocated_storage = var.rds_allocated_storage
-  multi_az          = var.environment == "production"
+  username               = local.credentials.db_username
+  instance_class         = var.rds_instance_class
+  engine_version         = var.rds_engine_version
+  allocated_storage      = var.rds_allocated_storage
+  multi_az               = var.environment == "production"
+  master_db_instance_arn = var.rds_master_db_instance_arn
+  is_read_replica        = var.rds_is_read_replica
 }

--- a/stack/app/rds.tf
+++ b/stack/app/rds.tf
@@ -21,7 +21,7 @@ module "rds" {
   region                     = var.region
   vpc_id                     = module.vpc.id
   password                   = local.credentials.db_root_password
-  kms_key_arn                = coalesce(var.rds_master_db_kms_key_arn, module.rds-kms-key.arn)
+  kms_key_arn                = var.rds_master_db_kms_key_arn == null ? module.rds-kms-key[0].arn : var.rds_master_db_kms_key_arn
   subnet_ids                 = module.vpc.subnet_private_ids
   allow_from_security_groups = [module.ecs.ecs_security_group_id]
 

--- a/stack/app/rds.tf
+++ b/stack/app/rds.tf
@@ -10,6 +10,7 @@ module "rds-kms-key" {
 
   # Optional
   deletion_window_in_days = var.kms_deletion_window_in_days
+  multi_region            = var.rds_multi_region_kms_key
 }
 
 module "rds" {

--- a/stack/app/rds.tf
+++ b/stack/app/rds.tf
@@ -20,13 +20,13 @@ module "rds" {
   account_id                 = var.account_id
   region                     = var.region
   vpc_id                     = module.vpc.id
-  password                   = local.credentials.db_root_password
+  password                   = var.rds_is_read_replica ? null : local.credentials.db_root_password
   kms_key_arn                = var.rds_master_db_kms_key_arn == null ? module.rds-kms-key[0].arn : var.rds_master_db_kms_key_arn
   subnet_ids                 = module.vpc.subnet_private_ids
   allow_from_security_groups = [module.ecs.ecs_security_group_id]
 
   # optional
-  username               = local.credentials.db_username
+  username               = var.rds_is_read_replica ? null : local.credentials.db_username
   instance_class         = var.rds_instance_class
   engine_version         = var.rds_engine_version
   allocated_storage      = var.rds_allocated_storage

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -96,6 +96,22 @@ variable "elasticache_snapshot_retention_limit" {
 # =============== Elasticache ================ #
 
 # =============== RDS ================ #
+variable "rds_is_read_replica" {
+  type    = bool
+  default = false
+}
+variable "rds_master_db_instance_arn" {
+  default = null
+  type    = string
+}
+variable "rds_master_db_region" {
+  type    = string
+  default = null
+}
+variable "rds_master_db_vpc_id" {
+  type    = string
+  default = null
+}
 variable "rds_instance_class" {
   type    = string
   default = "db.t3.micro"

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -110,7 +110,7 @@ variable "rds_cross_region_kms_keys_arns" {
   default = []
 }
 # set the key for the master DB to multi-region if you have read replicas in other regions
-variable "multi_region_kms_key" {
+variable "rds_multi_region_kms_key" {
   type    = bool
   default = false
 }

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -166,4 +166,9 @@ variable "secret_arns" {
   description = "arns of the secret manager that ECS can access"
   default     = []
 }
+
+variable "regional" {
+  type    = bool
+  default = true
+}
 # =============== ECS ================ #

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -101,6 +101,10 @@ variable "elasticache_snapshot_retention_limit" {
 # =============== Elasticache ================ #
 
 # =============== RDS ================ #
+variable "rds_name" {
+  type    = string
+  default = null
+}
 variable "rds_is_read_replica" {
   type    = bool
   default = false

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -137,6 +137,11 @@ variable "allow_internal_traffic_to_ports" {
   default = []
 }
 
+variable "ecs_name" {
+  type    = string
+  default = null
+}
+
 variable "allowlisted_ssh_ips" {
   type    = list(string)
   default = []

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -109,6 +109,11 @@ variable "rds_cross_region_kms_keys_arns" {
   type    = list(string)
   default = []
 }
+# set the key for the master DB to multi-region if you have read replicas in other regions
+variable "multi_region_kms_key" {
+  type    = bool
+  default = false
+}
 variable "rds_is_read_replica" {
   type    = bool
   default = false

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -105,10 +105,6 @@ variable "rds_name" {
   type    = string
   default = null
 }
-variable "rds_cross_region_kms_keys_arns" {
-  type    = list(string)
-  default = []
-}
 # set the key for the master DB to multi-region if you have read replicas in other regions
 variable "rds_multi_region_kms_key" {
   type    = bool

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -105,6 +105,10 @@ variable "rds_name" {
   type    = string
   default = null
 }
+variable "rds_cross_region_kms_keys_arns" {
+  type    = list(string)
+  default = []
+}
 variable "rds_is_read_replica" {
   type    = bool
   default = false

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -19,6 +19,11 @@ variable "account_id" {
 variable "domain_name" {
   type = string
 }
+
+variable "skip_cloudflare" {
+  type    = bool
+  default = false
+}
 # =============== Certificate Manager ================ #
 
 # =============== S3 private ================ #

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -112,6 +112,10 @@ variable "rds_master_db_vpc_id" {
   type    = string
   default = null
 }
+variable "rds_master_db_kms_key_arn" {
+  type    = string
+  default = null
+}
 variable "rds_instance_class" {
   type    = string
   default = "db.t3.micro"

--- a/stack/app/versions.tf
+++ b/stack/app/versions.tf
@@ -6,8 +6,9 @@ terraform {
     }
 
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4.0"
+      source                = "hashicorp/aws"
+      version               = ">= 4.0"
+      configuration_aliases = [aws.peer]
     }
   }
   required_version = ">= 1.0"

--- a/stack/app/versions.tf
+++ b/stack/app/versions.tf
@@ -6,9 +6,8 @@ terraform {
     }
 
     aws = {
-      source                = "hashicorp/aws"
-      version               = ">= 4.0"
-      configuration_aliases = [aws.peer]
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
     }
   }
   required_version = ">= 1.0"

--- a/stack/app/vpc-peering.tf
+++ b/stack/app/vpc-peering.tf
@@ -2,6 +2,11 @@ module "vpc-peering" {
   source = "../../vpc-peering"
   count  = var.rds_is_read_replica ? 1 : 0
 
+  providers = {
+    aws      = aws
+    aws.peer = aws.peer
+  }
+
   project     = var.project
   environment = var.environment
 

--- a/stack/app/vpc-peering.tf
+++ b/stack/app/vpc-peering.tf
@@ -3,8 +3,8 @@ module "vpc-peering" {
   count  = var.rds_is_read_replica ? 1 : 0
 
   providers = {
-    aws.default = aws.default
-    aws.peer    = aws.peer
+    aws      = aws
+    aws.peer = aws.peer
   }
 
   project     = var.project

--- a/stack/app/vpc-peering.tf
+++ b/stack/app/vpc-peering.tf
@@ -15,4 +15,6 @@ module "vpc-peering" {
 
   accepter_region = var.rds_master_db_region
   accepter_vpc_id = var.rds_master_db_vpc_id
+
+  rds_cross_region_kms_keys_arns = var.rds_cross_region_kms_keys_arns
 }

--- a/stack/app/vpc-peering.tf
+++ b/stack/app/vpc-peering.tf
@@ -3,8 +3,8 @@ module "vpc-peering" {
   count  = var.rds_is_read_replica ? 1 : 0
 
   providers = {
-    aws      = aws
-    aws.peer = aws.peer
+    aws.default = aws.default
+    aws.peer    = aws.peer
   }
 
   project     = var.project

--- a/stack/app/vpc-peering.tf
+++ b/stack/app/vpc-peering.tf
@@ -16,5 +16,5 @@ module "vpc-peering" {
   accepter_region = var.rds_master_db_region
   accepter_vpc_id = var.rds_master_db_vpc_id
 
-  rds_cross_region_kms_keys_arns = var.rds_cross_region_kms_keys_arns
+  cross_region_kms_keys_arns = var.rds_cross_region_kms_keys_arns
 }

--- a/stack/app/vpc-peering.tf
+++ b/stack/app/vpc-peering.tf
@@ -15,6 +15,4 @@ module "vpc-peering" {
 
   accepter_region = var.rds_master_db_region
   accepter_vpc_id = var.rds_master_db_vpc_id
-
-  cross_region_kms_keys_arns = var.rds_cross_region_kms_keys_arns
 }

--- a/stack/app/vpc-peering.tf
+++ b/stack/app/vpc-peering.tf
@@ -1,0 +1,13 @@
+module "vpc-peering" {
+  source = "../../vpc-peering"
+  count  = var.rds_is_read_replica ? 1 : 0
+
+  project     = var.project
+  environment = var.environment
+
+  requester_region = var.region
+  requester_vpc_id = module.vpc.id
+
+  accepter_region = var.rds_master_db_region
+  accepter_vpc_id = var.rds_master_db_vpc_id
+}

--- a/stack/setup/README.md
+++ b/stack/setup/README.md
@@ -48,8 +48,9 @@ module "stack-setup" {
   domain             = "example.com"
 
   # Optional
-  add_wildcard_subdomains = true
-  alternative_domains         = []
+  add_wildcard_subdomains        = true
+  alternative_domains            = []
+  is_read_replica_on_same_domain = false # skips cloudflare
 
   # KMS
   kms_deletion_window_in_days = 30

--- a/stack/setup/README.md
+++ b/stack/setup/README.md
@@ -55,6 +55,9 @@ module "stack-setup" {
   # KMS
   kms_deletion_window_in_days = 30
   eips_nat_count              = 1 # for production use, set this to the number of AZs
+
+  # In case this stack has a read-replica RDS in a different region
+  rds_cross_region_kms_key_arn = null
 }
 ```
 

--- a/stack/setup/README.md
+++ b/stack/setup/README.md
@@ -79,4 +79,9 @@ output "app_secrets-kms-key" {
 output "terraform_secrets-kms-key" {
   value = module.stack-setup.terraform_secrets-kms-key
 }
+
+output "kms-key-replica-rds-arn" {
+  value = module.stack-setup.kms-key-replica-rds-arn
+}
+
 ```

--- a/stack/setup/cloudflare.tf
+++ b/stack/setup/cloudflare.tf
@@ -17,7 +17,7 @@ data "cloudflare_zone" "default" {
 # domain validation
 resource "cloudflare_record" "validation" {
   # We assume that a read-replica stack runs on the same domain, hence we skip Cloudflare
-  count = var.rds_is_read_replica ? 0 : length(local.distinct_domain_names)
+  count = var.is_read_replica_on_same_domain ? 0 : length(local.distinct_domain_names)
 
   zone_id = data.cloudflare_zone.default.id
   name    = element(local.domain_validation_options, count.index)["resource_record_name"]
@@ -28,7 +28,7 @@ resource "cloudflare_record" "validation" {
 }
 
 resource "aws_acm_certificate_validation" "default" {
-  count = var.rds_is_read_replica ? 0 : 1
+  count = var.is_read_replica_on_same_domain ? 0 : 1
 
   certificate_arn         = aws_acm_certificate.main.arn
   validation_record_fqdns = cloudflare_record.validation.*.hostname

--- a/stack/setup/cloudflare.tf
+++ b/stack/setup/cloudflare.tf
@@ -16,7 +16,8 @@ data "cloudflare_zone" "default" {
 
 # domain validation
 resource "cloudflare_record" "validation" {
-  count = length(local.distinct_domain_names)
+  # We assume that a read-replica stack runs on the same domain, hence we skip Cloudflare
+  count = var.rds_is_read_replica ? 0 : length(local.distinct_domain_names)
 
   zone_id = data.cloudflare_zone.default.id
   name    = element(local.domain_validation_options, count.index)["resource_record_name"]
@@ -27,7 +28,8 @@ resource "cloudflare_record" "validation" {
 }
 
 resource "aws_acm_certificate_validation" "default" {
-  certificate_arn = aws_acm_certificate.main.arn
+  count = var.rds_is_read_replica ? 0 : 1
 
+  certificate_arn         = aws_acm_certificate.main.arn
   validation_record_fqdns = cloudflare_record.validation.*.hostname
 }

--- a/stack/setup/main.tf
+++ b/stack/setup/main.tf
@@ -9,6 +9,16 @@ locals {
   }
 }
 
+module "kms-key-replica-rds" {
+  source = "../../kms-key-replica"
+  count  = var.rds_cross_region_kms_key_arn == null ? 0 : 1
+
+  master_kms_key_arn = var.rds_cross_region_kms_key_arn
+  environment        = var.environment
+  project            = var.project
+  alias              = "rds"
+}
+
 module "secrets" {
   source = "../../secrets"
 

--- a/stack/setup/outputs.tf
+++ b/stack/setup/outputs.tf
@@ -19,3 +19,7 @@ output "eips-nat" {
     for eip in aws_eip.nat : eip.public_ip
   ]
 }
+
+output "kms-key-replica-rds-arn" {
+  value = var.rds_cross_region_kms_key_arn == null ? "Not applicable if 'rds_cross_region_kms_key_arn' is not set." : module.kms-key-replica-rds[0].arn
+}

--- a/stack/setup/outputs.tf
+++ b/stack/setup/outputs.tf
@@ -21,5 +21,5 @@ output "eips-nat" {
 }
 
 output "kms-key-replica-rds-arn" {
-  value = var.rds_cross_region_kms_key_arn == null ? "Not applicable if 'rds_cross_region_kms_key_arn' is not set." : module.kms-key-replica-rds[0].arn
+  value = var.rds_cross_region_kms_key_arn == null ? "Not applicable if 'rds_cross_region_kms_key_arn' is not set." : join("", module.kms-key-replica-rds.*.arn)
 }

--- a/stack/setup/variables.tf
+++ b/stack/setup/variables.tf
@@ -15,6 +15,11 @@ variable "add_wildcard_subdomains" {
   default = true
 }
 
+variable "is_read_replica_on_same_domain" {
+  type    = bool
+  default = false
+}
+
 variable "eips_nat_count" {
   type    = number
   default = 1

--- a/stack/setup/variables.tf
+++ b/stack/setup/variables.tf
@@ -34,3 +34,10 @@ variable "kms_deletion_window_in_days" {
   type    = number
   default = 30
 }
+
+
+# in case this stack has a read-replica RDS, we need to access the master DB KMS key
+variable "rds_cross_region_kms_key_arn" {
+  type    = string
+  default = null
+}

--- a/vpc-peering/README.md
+++ b/vpc-peering/README.md
@@ -1,0 +1,52 @@
+# Terraform Module: RDS
+
+Used to create a VPC peering between two VPCs.
+
+Both VPCs may be in different geo-regions.
+
+The VPC Peering Connection resource is created in the "accepter"'s region/account.
+The default AWS provider is used for the "requester". The AWS provider for the accepter must be configured as outlined below.
+
+
+
+:warning: Be aware, that both VPCs must use a different CIDR block!
+
+
+
+## Usage
+
+```terraform
+# versions.tf
+
+# Requester's credentials
+provider "aws" {
+  region  = "eu-central-1"
+  profile = "dbl-works"
+}
+
+# Accepter's credentials
+provider "aws" {
+  alias = "peer"
+
+  region  = "us-east-1"
+  profile = "dbl-works"
+}
+```
+
+
+```terraform
+# main.tf
+
+module "vpc-peering" {
+  source = "github.com/dbl-works/terraform//vpc-peering?ref=v2021.07.01"
+
+  project     = "project-name"
+  environment = "production"
+
+  requester_region = "eu-central-1"
+  requester_vpc_id = "module.vpc-eu.id"
+
+  accepter_region = "us-east-1"
+  accepter_vpc_id = "module.vpc-us.id"
+}
+```

--- a/vpc-peering/README.md
+++ b/vpc-peering/README.md
@@ -40,6 +40,11 @@ provider "aws" {
 module "vpc-peering" {
   source = "github.com/dbl-works/terraform//vpc-peering?ref=v2021.07.01"
 
+  providers = {
+    aws      = aws
+    aws.peer = aws.peer
+  }
+
   project     = "project-name"
   environment = "production"
 

--- a/vpc-peering/README.md
+++ b/vpc-peering/README.md
@@ -53,5 +53,8 @@ module "vpc-peering" {
 
   accepter_region = "us-east-1"
   accepter_vpc_id = "module.vpc-us.id"
+
+  # optional
+  cross_region_kms_keys_arns = [] # to allow using the same key across regions, e.g. for RDS read replicas
 }
 ```

--- a/vpc-peering/main.tf
+++ b/vpc-peering/main.tf
@@ -17,30 +17,3 @@ resource "aws_vpc_peering_connection" "peer" {
     Environment = var.environment
   }
 }
-
-# Accepter's side of the connection.
-resource "aws_vpc_peering_connection_accepter" "peer" {
-  provider                  = aws.peer
-  vpc_peering_connection_id = aws_vpc_peering_connection.peer.id
-  auto_accept               = true
-
-  tags = {
-    Side        = "Accepter"
-    Name        = "${var.project}-${var.environment}-${var.accepter_region}-${var.requester_region}"
-    Project     = var.project
-    Environment = var.environment
-  }
-}
-
-
-# https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-auth.html
-# if we create a RDS read-replica in a different region, we must pass the KMS key ARN to the replica
-# so that the replica can read an encrypted master DB. KMS keys by default are only accessible in their
-# region, hence we must create a replica of the RDS key.
-resource "aws_kms_replica_key" "replica" {
-  for_each = toset(var.cross_region_kms_keys_arns)
-
-  description             = "Multi-Region replica key"
-  deletion_window_in_days = 7
-  primary_key_arn         = each.key
-}

--- a/vpc-peering/main.tf
+++ b/vpc-peering/main.tf
@@ -1,0 +1,33 @@
+data "aws_caller_identity" "peer" {
+  provider = aws.peer
+}
+
+# Requester's side of the connection.
+resource "aws_vpc_peering_connection" "peer" {
+  vpc_id        = var.requester_vpc_id
+  peer_vpc_id   = var.accepter_vpc_id
+  peer_owner_id = data.aws_caller_identity.peer.account_id
+  peer_region   = var.accepter_region
+  auto_accept   = false
+
+  tags = {
+    Side        = "Requester"
+    Name        = "${var.project}-${var.environment}-${var.requester_region}-${var.accepter_region}"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+# Accepter's side of the connection.
+resource "aws_vpc_peering_connection_accepter" "peer" {
+  provider                  = aws.peer
+  vpc_peering_connection_id = aws_vpc_peering_connection.peer.id
+  auto_accept               = true
+
+  tags = {
+    Side        = "Accepter"
+    Name        = "${var.project}-${var.environment}-${var.accepter_region}-${var.requester_region}"
+    Project     = var.project
+    Environment = var.environment
+  }
+}

--- a/vpc-peering/main.tf
+++ b/vpc-peering/main.tf
@@ -17,3 +17,17 @@ resource "aws_vpc_peering_connection" "peer" {
     Environment = var.environment
   }
 }
+
+# Accepter's side of the connection.
+resource "aws_vpc_peering_connection_accepter" "peer" {
+  provider                  = aws.peer
+  vpc_peering_connection_id = aws_vpc_peering_connection.peer.id
+  auto_accept               = true
+
+  tags = {
+    Side        = "Accepter"
+    Name        = "${var.project}-${var.environment}-${var.accepter_region}-${var.requester_region}"
+    Project     = var.project
+    Environment = var.environment
+  }
+}

--- a/vpc-peering/main.tf
+++ b/vpc-peering/main.tf
@@ -31,3 +31,16 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
     Environment = var.environment
   }
 }
+
+
+# https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-auth.html
+# if we create a RDS read-replica in a different region, we must pass the KMS key ARN to the replica
+# so that the replica can read an encrypted master DB. KMS keys by default are only accessible in their
+# region, hence we must create a replica of the RDS key.
+resource "aws_kms_replica_key" "replica" {
+  for_each = toset(var.cross_region_kms_keys_arns)
+
+  description             = "Multi-Region replica key"
+  deletion_window_in_days = 7
+  primary_key_arn         = each.key
+}

--- a/vpc-peering/outputs.tf
+++ b/vpc-peering/outputs.tf
@@ -1,0 +1,7 @@
+output "accept_status-requester" {
+  value = aws_vpc_peering_connection.peer.accept_status
+}
+
+output "accept_status-accepter" {
+  value = aws_vpc_peering_connection_accepter.peer.accept_status
+}

--- a/vpc-peering/variables.tf
+++ b/vpc-peering/variables.tf
@@ -1,0 +1,25 @@
+variable "project" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+# requester
+variable "requester_region" {
+  type = string
+}
+
+variable "requester_vpc_id" {
+  type = string
+}
+
+# accepter
+variable "accepter_region" {
+  type = string
+}
+
+variable "accepter_vpc_id" {
+  type = string
+}

--- a/vpc-peering/variables.tf
+++ b/vpc-peering/variables.tf
@@ -23,8 +23,3 @@ variable "accepter_region" {
 variable "accepter_vpc_id" {
   type = string
 }
-
-variable "cross_region_kms_keys_arns" {
-  type    = list(string)
-  default = []
-}

--- a/vpc-peering/variables.tf
+++ b/vpc-peering/variables.tf
@@ -23,3 +23,8 @@ variable "accepter_region" {
 variable "accepter_vpc_id" {
   type = string
 }
+
+variable "cross_region_kms_keys_arns" {
+  type    = list(string)
+  default = []
+}

--- a/vpc-peering/versions.tf
+++ b/vpc-peering/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/vpc-peering/versions.tf
+++ b/vpc-peering/versions.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4.0"
+      source                = "hashicorp/aws"
+      version               = ">= 4.0"
+      configuration_aliases = [aws.peer]
     }
   }
   required_version = ">= 1.0"

--- a/vpc/vpc.tf
+++ b/vpc/vpc.tf
@@ -36,7 +36,7 @@ resource "aws_route" "all" {
 # DEPRECATED: This is the existing public network that allows internet access
 # range 10.0.0.0 - 10.0.2.255
 resource "aws_subnet" "public" {
-  count                   = 3
+  count                   = length(var.availability_zones)
   vpc_id                  = aws_vpc.vpc.id
   cidr_block              = cidrsubnet(var.cidr_block, 8, count.index + 1)
   map_public_ip_on_launch = true
@@ -58,7 +58,7 @@ resource "aws_route_table_association" "public" {
 # All outgoing traffic must go via NAT gateway
 # range 10.0.100.0 - 10.0.102.255
 resource "aws_subnet" "private" {
-  count                   = 3
+  count                   = length(var.availability_zones)
   vpc_id                  = aws_vpc.vpc.id
   cidr_block              = cidrsubnet(var.cidr_block, 8, count.index + 100)
   map_public_ip_on_launch = false


### PR DESCRIPTION
Adds the possibility to launch a stack with an RDS read replica and VPC Peering to connect to a "main"/"master" stack.

- new module: VPC Peering
- RDS can now be launched as read-replica
- stack can now be launched with a RDS read replica and vpc-peering
- require aws config alias for stack
- fix passing multiple providers to submodule
- Update README.md
- CI hack for terraform bug


## testing
Members of DBL can see the terraform scripts for launching a 2nd stack in another geo region here: https://github.com/dbl-works/test-application/pull/6

<img width="1143" alt="Screenshot 2022-07-03 at 20 29 35" src="https://user-images.githubusercontent.com/20702503/177040645-3dcc4b65-b00d-4b53-b3e2-f40893cbc422.png">

<img width="1136" alt="Screenshot 2022-07-03 at 20 28 08" src="https://user-images.githubusercontent.com/20702503/177040649-aa3eb48c-e64d-4f7b-b648-2218da3cfa22.png">
