### PR TITLE
[Chore] Pass only 1 availability_zone to the VPN module 

### DIFF
--- a/vpn/README.md
+++ b/vpn/README.md
@@ -21,7 +21,7 @@ module "outline-vpn" {
   # optional
   region             = "eu-central-1"
   instance_type      = "t3.micro"
-  availability_zones = ["${var.region}a", "${var.region}b", "${var.region}c"] # see warning below
+  availability_zone  = "${var.region}a" # see warning below
 }
 ```
 

--- a/vpn/instance.tf
+++ b/vpn/instance.tf
@@ -2,8 +2,8 @@
 resource "aws_instance" "main" {
   ami                         = var.ami_id
   instance_type               = var.instance_type
-  associate_public_ip_address = true                               # Needs to be true, even if allocating an EIP
-  availability_zone           = element(var.availability_zones, 0) # "${var.region}a"
+  associate_public_ip_address = true # Needs to be true, even if allocating an EIP
+  availability_zone           = local.availability_zone
   key_name                    = var.key_name
   subnet_id                   = module.vpc.subnet_public_ids[0]
   vpc_security_group_ids = [

--- a/vpn/variables.tf
+++ b/vpn/variables.tf
@@ -16,12 +16,12 @@ variable "instance_type" {
   default = "t3.micro"
 }
 
-variable "availability_zones" {
-  type    = list(any)
+variable "availability_zone" {
+  type    = string
   default = null
 }
 
 # can't use variables inside other variables, so we need to define a local variable
 locals {
-  availability_zones = var.availability_zones == null ? ["${var.region}a", "${var.region}b", "${var.region}c"] : var.availability_zones
+  availability_zone = var.availability_zone == null ? "${var.region}a" : var.availability_zone
 }

--- a/vpn/vpc.tf
+++ b/vpn/vpc.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source = "../vpc"
 
   account_id         = var.account_id
-  availability_zones = local.availability_zone
+  availability_zones = [local.availability_zone]
   environment        = var.environment
   project            = var.project
   region             = var.region

--- a/vpn/vpc.tf
+++ b/vpn/vpc.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source = "../vpc"
 
   account_id         = var.account_id
-  availability_zones = local.availability_zones
+  availability_zones = local.availability_zone
   environment        = var.environment
   project            = var.project
   region             = var.region


### PR DESCRIPTION
### Summary

- allow passing AZ's since only 1 AZ is needed for the creation of VPN