### PR TITLE
Allow launching stack with VPC peering without RDS read-replica

### DIFF
--- a/ecs/security-groups.tf
+++ b/ecs/security-groups.tf
@@ -62,7 +62,7 @@ resource "aws_security_group" "ecs" {
 resource "aws_security_group_rule" "ecs" {
   for_each                 = toset(var.allow_internal_traffic_to_ports)
   type                     = "ingress"
-  from_port                = each.key ## ??
+  from_port                = each.key
   to_port                  = each.key
   protocol                 = "tcp"
   security_group_id        = aws_security_group.ecs.id

--- a/ecs/security-groups.tf
+++ b/ecs/security-groups.tf
@@ -62,7 +62,7 @@ resource "aws_security_group" "ecs" {
 resource "aws_security_group_rule" "ecs" {
   for_each                 = toset(var.allow_internal_traffic_to_ports)
   type                     = "ingress"
-  from_port                = 0
+  from_port                = each.key ## ??
   to_port                  = each.key
   protocol                 = "tcp"
   security_group_id        = aws_security_group.ecs.id

--- a/rds/README.md
+++ b/rds/README.md
@@ -32,6 +32,7 @@ module "db" {
   multi_az            = false
   regional            = false # set to `true` to append region to name, unless name given
   name                = null # defaults to "${var.project}-${var.environment}", may need to be unique per region
+  snapshot_identifier = "" # crate from snapshot
 
   # when creating a read-replica
   master_db_instance_arn = null  # ARN of the master database

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -26,6 +26,8 @@ resource "aws_db_instance" "main" {
   monitoring_role_arn             = aws_iam_role.rds-enhanced-monitoring.arn
   performance_insights_enabled    = true
   performance_insights_kms_key_id = var.kms_key_arn
+  snapshot_identifier             = var.snapshot_identifier
+
   enabled_cloudwatch_logs_exports = [
     "postgresql",
     "upgrade",
@@ -46,6 +48,7 @@ resource "aws_db_instance" "main" {
     ignore_changes = [
       engine_version, # AWS will auto-update minor version changes
       db_name,        # if you didn't use this before it would re-create your RDS instance
+      snapshot_identifier,
     ]
   }
 }

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -20,6 +20,11 @@ variable "multi_az" {
   default = false
 }
 
+variable "snapshot_identifier" {
+  type    = string
+  default = null
+}
+
 # Credentials for the root RDS user
 # Only to be used in initial setup, never by applications
 variable "username" {

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -114,6 +114,7 @@ module "stack" {
 
   # vpc
   vpc_cidr_block = "10.0.0.0/16"
+  vpc_peering    = false # automatically set to "true" if "rds_is_read_replica" is "true".
 }
 ```
 

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -28,10 +28,10 @@ module "ecs" {
 
   allow_internal_traffic_to_ports = var.allow_internal_traffic_to_ports
 
-  allowlisted_ssh_ips = flatten(concat([
+  allowlisted_ssh_ips = distinct(flatten(concat([
     var.allowlisted_ssh_ips,
     var.vpc_cidr_block
-  ]))
+  ])))
 
   grant_read_access_to_s3_arns = var.grant_read_access_to_s3_arns
   grant_write_access_to_s3_arns = flatten(concat([

--- a/stack/app/outputs.tf
+++ b/stack/app/outputs.tf
@@ -10,6 +10,10 @@ output "redis_url" {
   value = module.elasticache.endpoint
 }
 
+output "vpc_id" {
+  value = module.vpc.id
+}
+
 # Security groups, for linking with other resources
 output "alb_security_group_id" {
   value = module.ecs.alb_security_group_id

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -73,6 +73,11 @@ variable "vpc_availability_zones" {
 variable "vpc_cidr_block" {
   type = string
 }
+
+variable "vpc_peering" {
+  type    = bool
+  default = false
+}
 # =============== VPC ================ #
 
 

--- a/stack/app/vpc-peering.tf
+++ b/stack/app/vpc-peering.tf
@@ -1,6 +1,10 @@
+locals {
+  enable_vpc_peering = var.vpc_peering || var.rds_is_read_replica
+}
+
 module "vpc-peering" {
   source = "../../vpc-peering"
-  count  = var.rds_is_read_replica ? 1 : 0
+  count  = local.enable_vpc_peering ? 1 : 0
 
   providers = {
     aws      = aws


### PR DESCRIPTION
* Allow launching stack with VPC peering without RDS read-replica
* "bug" fix: if passed duplicated IP (ranges) for the ecs-ssh ingress policy, we get a hard error. We now ensure, this is a unique list