### PR TITLE
Allow passing multiple CIDR blocks to Elasticache Security Group Rule

### DIFF
--- a/elasticache/README.md
+++ b/elasticache/README.md
@@ -10,12 +10,13 @@ A reopsitory for setting up an elasticache cluster.
 module "elasticache" {
   source = "github.com/dbl-works/terraform//elasticache?ref=v2021.08.24"
 
-  project            = local.project
-  environment        = local.environment
-  vpc_id             = module.vpc.id
-  vpc_cidr           = local.cidr_block
-  subnet_ids         = module.vpc.subnet_private_ids
-  kms_key_arn        = var.kms_key_arn # "kms_app_arn" if you use the "stack" module, i.e. the key used for the application
+  project                = local.project
+  environment            = local.environment
+  vpc_id                 = module.vpc.id
+  allow_from_cidr_blocks = [local.cidr_block] # add more if you need access e.g. through a peering from another VPC
+  vpc_cidr               = local.cidr_block # deprecated in favor of `vpc_cidr_blocks`
+  subnet_ids             = module.vpc.subnet_private_ids
+  kms_key_arn            = var.kms_key_arn # "kms_app_arn" if you use the "stack" module, i.e. the key used for the application
 
   # required only for non cluster mode
   availability_zones = ["eu-central-1a", "eu-central-1b", "eu-central-1c"]

--- a/elasticache/security-group.tf
+++ b/elasticache/security-group.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 resource "aws_security_group_rule" "main" {
-  count = length(local.vpc_cidr_blocks)
+  count = length(local.vpc_cidr_blocks) # avoid creating any, if no CIDR blocks are passed
 
   type              = "ingress"
   from_port         = 6379
@@ -28,7 +28,5 @@ resource "aws_security_group_rule" "main" {
   protocol          = "tcp"
   security_group_id = aws_security_group.main.id
 
-  cidr_blocks = [
-    local.vpc_cidr_blocks[count.index],
-  ]
+  cidr_blocks = local.vpc_cidr_blocks
 }

--- a/elasticache/security-group.tf
+++ b/elasticache/security-group.tf
@@ -7,22 +7,28 @@ resource "aws_security_group" "main" {
     Project     = var.project
     Environment = var.environment
   }
+}
 
-  # egress {
-  #   from_port = 0
-  #   to_port = 0
-  #   protocol = -1
-  #   cidr_blocks = ["0.0.0.0/0"]
-  # }
+# to avoid breaking changes for switching from "vpc_cidr" ( string ) to "allow_from_cidr_blocks" ( list )
+locals {
+  vpc_cidr_blocks = distinct(compact(flatten(
+    [
+      var.allow_from_cidr_blocks,
+      var.vpc_cidr,
+    ]
+  )))
 }
 
 resource "aws_security_group_rule" "main" {
+  count = length(local.vpc_cidr_blocks)
+
   type              = "ingress"
   from_port         = 6379
   to_port           = 6379
   protocol          = "tcp"
   security_group_id = aws_security_group.main.id
+
   cidr_blocks = [
-    var.vpc_cidr,
+    local.vpc_cidr_blocks[count.index],
   ]
 }

--- a/elasticache/security-group.tf
+++ b/elasticache/security-group.tf
@@ -22,11 +22,14 @@ locals {
 resource "aws_security_group_rule" "main" {
   count = length(local.vpc_cidr_blocks) # avoid creating any, if no CIDR blocks are passed
 
+  description       = "From CIDR Block: ${local.vpc_cidr_blocks[count.index]}"
   type              = "ingress"
   from_port         = 6379
   to_port           = 6379
   protocol          = "tcp"
   security_group_id = aws_security_group.main.id
 
-  cidr_blocks = local.vpc_cidr_blocks
+  cidr_blocks = [
+    local.vpc_cidr_blocks[count.index],
+  ]
 }

--- a/elasticache/variables.tf
+++ b/elasticache/variables.tf
@@ -1,9 +1,20 @@
 variable "project" {}
 variable "environment" {}
 variable "vpc_id" {}
-variable "vpc_cidr" {}
 variable "kms_key_arn" {}
 variable "subnet_ids" { type = list(string) }
+
+variable "allow_from_cidr_blocks" {
+  type    = list(string)
+  default = []
+}
+
+# deprecated
+variable "vpc_cidr" {
+  type    = string
+  default = ""
+}
+
 variable "availability_zones" {
   type        = list(string)
   default     = []

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -127,8 +127,9 @@ module "stack" {
   elasticache_data_tiering_enabled          = false # see the README in the Elasticache Module
 
   # vpc
-  vpc_cidr_block = "10.0.0.0/16"
-  vpc_peering    = false # automatically set to "true" if "rds_is_read_replica" is "true".
+  vpc_cidr_block     = "10.0.0.0/16"
+  vpc_peering        = false # automatically set to "true" if "rds_is_read_replica" is "true".
+  remote_cidr_blocks = [] # for peering connections
 }
 ```
 

--- a/stack/app/elasticache.tf
+++ b/stack/app/elasticache.tf
@@ -6,8 +6,12 @@ module "elasticache" {
   environment = var.environment
   vpc_id      = module.vpc.id
   subnet_ids  = module.vpc.subnet_private_ids
-  vpc_cidr    = var.vpc_cidr_block
   kms_key_arn = var.kms_app_arn
+
+  allow_from_cidr_blocks = distinct(compact(flatten([
+    var.vpc_cidr_block,
+    var.remote_cidr_blocks,
+  ])))
 
   # optional
   node_type                = var.elasticache_node_type

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -89,6 +89,12 @@ variable "vpc_peering" {
   type    = bool
   default = false
 }
+
+# CIDR blocks from all regions that are not this region
+variable "remote_cidr_blocks" {
+  type    = list(string)
+  default = []
+}
 # =============== VPC ================ #
 
 


### PR DESCRIPTION
Optionally allow that we can access a Redis cluster in another VPC/region.

Tested on the test application ✅ 