### PR TITLE
Add postgres14 parameter group

### DIFF
--- a/rds/parameter-group.tf
+++ b/rds/parameter-group.tf
@@ -14,3 +14,20 @@ resource "aws_db_parameter_group" "postgres13" {
     value = 1
   }
 }
+
+resource "aws_db_parameter_group" "postgres14" {
+  name   = "${var.project}-${var.environment}-postgres14"
+  family = "postgres14"
+  parameter {
+    name  = "log_statement"
+    value = "all"
+  }
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "0"
+  }
+  parameter {
+    name  = "rds.force_ssl"
+    value = 1
+  }
+}

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -11,7 +11,7 @@ resource "aws_db_instance" "main" {
   username                            = var.is_read_replica ? null : var.username # credentials of the master DB are used
   password                            = var.is_read_replica ? null : var.password # credentials of the master DB are used
   iam_database_authentication_enabled = true
-  parameter_group_name                = var.engine_version == 14 ? aws_db_parameter_group.postgres14.name : aws_db_parameter_group.postgres13.name
+  parameter_group_name                = var.engine_version == "14" ? aws_db_parameter_group.postgres14.name : aws_db_parameter_group.postgres13.name
   apply_immediately                   = true
   multi_az                            = var.multi_az
   publicly_accessible                 = var.publicly_accessible

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -11,7 +11,7 @@ resource "aws_db_instance" "main" {
   username                            = var.is_read_replica ? null : var.username # credentials of the master DB are used
   password                            = var.is_read_replica ? null : var.password # credentials of the master DB are used
   iam_database_authentication_enabled = true
-  parameter_group_name                = aws_db_parameter_group.postgres13.name
+  parameter_group_name                = var.engine_version == 14 ? aws_db_parameter_group.postgres14.name : aws_db_parameter_group.postgres13.name
   apply_immediately                   = true
   multi_az                            = var.multi_az
   publicly_accessible                 = var.publicly_accessible

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -7,7 +7,10 @@ variable "project" {}
 variable "environment" {}
 
 variable "instance_class" { default = "db.t3.micro" }
-variable "engine_version" { default = "13" }
+variable "engine_version" {
+  default = "14"
+  type    = string
+}
 variable "allocated_storage" { default = 100 }
 
 variable "publicly_accessible" {


### PR DESCRIPTION
This will allow upgrade from `13` -> `14`. We can't delete a parameter group or modify it's "family" while it is associated with an instance.

The idea here is we would always support exactly 2 versions of pg with our latest module.

Once 15 is accepted and stable, we would remove `13` from the module and have `14`/`15`