### PR TITLE
Elasticache: Allow opt-out of automatic failover

### DIFF
--- a/elasticache/elasticache.tf
+++ b/elasticache/elasticache.tf
@@ -21,7 +21,7 @@ resource "aws_elasticache_replication_group" "non_cluster_mode" {
   # but will result in a brief downtime as servers reboots.
   apply_immediately          = true
   multi_az_enabled           = var.multi_az_enabled
-  automatic_failover_enabled = true
+  automatic_failover_enabled = var.automatic_failover_enabled
   data_tiering_enabled       = var.data_tiering_enabled
 
   security_group_ids = [

--- a/elasticache/variables.tf
+++ b/elasticache/variables.tf
@@ -66,6 +66,11 @@ variable "multi_az_enabled" {
   default = true
 }
 
+variable "automatic_failover_enabled" {
+  type    = bool
+  default = true
+}
+
 variable "data_tiering_enabled" {
   type    = bool
   default = false


### PR DESCRIPTION
Smaller/test projects don't need the failover. Requires a minimum of 2 nodes to be active which doubles the cost.