### PR TITLE
[SC 2864] Add maxmemory_policy to elasticache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 This project does not follow SemVer, since modules are independent of each other; thus, SemVer does not make sense. Changes are grouped per module.
 
+## [unreleased]
+## Elasticache
+- added `maxmemory_policy` as the optional options. Default value is `volatile-lru`
+
 ## [v2022.08.05]
 ## Elasticache
 - `multi_az_enabled` can now optionally be turned off

--- a/elasticache/README.md
+++ b/elasticache/README.md
@@ -29,6 +29,7 @@ module "elasticache" {
   cluster_mode         = true
   data_tiering_enabled = false # only available for "r6gd" node types (see warning below)
   multi_az_enabled     = true # requires at least 1 replica
+  maxmemory_policy     = "noeviction" # Allowed values: volatile-lru,allkeys-lru,volatile-lfu,allkeys-lfu,volatile-random,allkeys-random,volatile-ttl,noeviction
 
   # To enable cluster mode, use a parameter group that has cluster mode enabled.
   # The default parameter groups provided by AWS end with ".cluster.on", for example default.redis6.x.cluster.on.

--- a/elasticache/elasticache.tf
+++ b/elasticache/elasticache.tf
@@ -86,6 +86,9 @@ resource "aws_elasticache_parameter_group" "main" {
 
   name = local.cluster_name
   # Family need to be specified so that we can copy keys n values from the existing parameter group
+  # The regexp will extract the family name from the parameter group name, eg:
+  # default.redis6.x => redis6.x
+  # default.redis6.x.cluster.on => redis6.x
   family = regex("[A-Za-z]+\\.([A-Za-z0-9]+\\.[A-Za-z0-9]+)", var.parameter_group_name)[0]
 
   parameter {

--- a/elasticache/variables.tf
+++ b/elasticache/variables.tf
@@ -81,6 +81,11 @@ variable "name" {
   default = null
 }
 
+variable "maxmemory_policy" {
+  type    = string
+  default = null
+}
+
 locals {
   elasticache_name = var.name == null ? "${var.project}-${var.environment}-elasticache" : "${var.project}-${var.environment}-${var.name}-elasticache"
   cluster_name     = var.name == null ? "${var.project}-${var.environment}" : "${var.project}-${var.environment}-${var.name}"


### PR DESCRIPTION
## Summary
Allow user to pass in `maxmemory_policy` to elasticache. If it is not passed, default value will be set as `volatile-lru`.
