### PR TITLE
Stack: Pass "region" to ECS module (fixes CloudWatch Dashboard)

### DIFF
--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -25,6 +25,7 @@ module "ecs" {
   certificate_arn   = data.aws_acm_certificate.default.arn
   regional          = var.regional
   name              = var.ecs_name # custom name when convention exceeds 32 chars
+  region            = var.region   # used for e.g CloudWatch metrics
 
   allow_internal_traffic_to_ports = var.allow_internal_traffic_to_ports
 


### PR DESCRIPTION
Cloudwatch metrics for stacks outside `eu-central-1` are not working when using the stack module.

## terraform plan

```terraform
Terraform will perform the following actions:

  # module.stack.module.ecs.aws_cloudwatch_dashboard.main will be updated in-place
  ~ resource "aws_cloudwatch_dashboard" "main" {
      ~ dashboard_body = jsonencode(
          ~ {
              ~ widgets = [
                  ~ {
                      ~ properties = {
                          ~ region  = "eu-central-1" -> "us-east-1"
                            # (7 unchanged elements hidden)
                        }
                        # (5 unchanged elements hidden)
                    },
                  ~ {
                      ~ properties = {
                          ~ metrics              = [
                              - [
                                  - {
                                      - expression = "100*(m1/m2)"
                                      - id         = "e1"
                                      - label      = "MemoryUsage"
                                      - region     = "eu-central-1"
                                      - yAxis      = "left"
                                    },
                                ],
                              + [
                                  + {
                                      + expression = "100*(m1/m2)"
                                      + id         = "e1"
                                      + label      = "MemoryUsage"
                                      + region     = "us-east-1"
                                      + yAxis      = "left"
                                    },
                                ],
                                [
                                    "ECS/ContainerInsights",
                                    "MemoryUtilized",
                                    "ServiceName",
                                    "web",
                                    "ClusterName",
                                    "${project}-production-us-east",
                                    {
                                        id      = "m1"
                                        visible = false
                                    },
                                ],
                                # (1 unchanged element hidden)
                            ]
                          ~ region               = "eu-central-1" -> "us-east-1"
                            # (7 unchanged elements hidden)
                        }
                        # (5 unchanged elements hidden)
                    },
                  ~ {
                      ~ properties = {
                          ~ region  = "eu-central-1" -> "us-east-1"
                            # (7 unchanged elements hidden)
                        }
                        # (5 unchanged elements hidden)
                    },
                  ~ {
                      ~ properties = {
                          ~ region               = "eu-central-1" -> "us-east-1"
                            # (8 unchanged elements hidden)
                        }
                        # (5 unchanged elements hidden)
                    },
                ]
            }
        )
        id             = "${project}-production-us-east-ecs"
        # (2 unchanged attributes hidden)
    }
```
## before

<img width="1459" alt="Screenshot 2022-08-18 at 19 10 18" src="https://user-images.githubusercontent.com/20702503/185456449-0a46f8dc-aeb1-4313-92c3-3e242173e0ad.png">

<img width="1526" alt="Screenshot 2022-08-18 at 19 10 35" src="https://user-images.githubusercontent.com/20702503/185456463-44b80536-12a5-4295-85d5-5e37f8014680.png">

## after
<img width="1462" alt="Screenshot 2022-08-18 at 19 20 07" src="https://user-images.githubusercontent.com/20702503/185456498-04870a03-481b-4724-95d5-371b2076b46a.png">

