### PR TITLE
ecs: Add ECS role name to ECS output

### DIFF
--- a/ecs/outputs.tf
+++ b/ecs/outputs.tf
@@ -28,6 +28,6 @@ output "https_alb_listener_arn" {
 }
 
 output "ecs_role_name" {
-  value = aws_iam_role.ecs-task-execution.name
+  value       = aws_iam_role.ecs-task-execution.name
   description = "ECS container instance IAM role. Attach policy for container instances to this role to add permissions for future features and enhancements as they are introduce."
 }

--- a/ecs/outputs.tf
+++ b/ecs/outputs.tf
@@ -26,3 +26,8 @@ output "ecs_security_group_id" {
 output "https_alb_listener_arn" {
   value = aws_alb_listener.https.arn
 }
+
+output "ecs_role_name" {
+  value = aws_iam_role.ecs-task-execution.name
+  description = "ECS container instance IAM role. Attach policy for container instances to this role to add permissions for future features and enhancements as they are introduce."
+}

--- a/stack/app/outputs.tf
+++ b/stack/app/outputs.tf
@@ -55,3 +55,8 @@ output "accept_status-accepter" {
 output "rds_kms_key_arn" {
   value = var.rds_master_db_kms_key_arn == null ? join("", module.rds-kms-key.*.arn) : "KMS ARN only printed for the master DB to be passed to each replica."
 }
+
+output "ecs_role_name" {
+  value       = module.ecs.ecs_role_name
+  description = "ECS container instance IAM role. Attach policy for container instances to this role to add permissions for future features and enhancements as they are introduce."
+}


### PR DESCRIPTION
### Summary
Add ECS role name to ECS output so user can know which role name to attach the policy to.