### PR TITLE
stack: Declare aws.peer in stack module

### DIFF
--- a/stack/app/versions.tf
+++ b/stack/app/versions.tf
@@ -6,8 +6,8 @@ terraform {
     }
 
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4.0"
+      source                = "hashicorp/aws"
+      version               = ">= 4.0"
       configuration_aliases = [aws.peer]
     }
   }

--- a/stack/app/versions.tf
+++ b/stack/app/versions.tf
@@ -8,6 +8,7 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 4.0"
+      configuration_aliases = [aws.peer]
     }
   }
   required_version = ">= 1.0"


### PR DESCRIPTION
### Summary
To get rid of the error below:
```
│ Warning: Provider aws.peer is undefined
│ 
│   on main.tf line 6, in module "stack":
│    6:     aws.peer = aws.peer
│ 
│ Module module.stack does not declare a provider named aws.peer.
│ If you wish to specify a provider configuration for the module, add an entry for aws.peer in the required_providers block within the module.
```

