### PR TITLE
Set RDS parameter wal_buffers to default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project does not follow SemVer, since modules are independent of each other
 
 ## RDS
 - add option to enable DB replication with new parameter `enable_replication` [#119](https://github.com/dbl-works/terraform/pull/119)
+- if `enable_replication` is changed on a running DB, the DB will need to be restarted manually
 
 ## [v2022.08.05]
 ## Elasticache

--- a/rds/parameter-group.tf
+++ b/rds/parameter-group.tf
@@ -24,6 +24,12 @@ resource "aws_db_parameter_group" "postgres13" {
     value        = var.enable_replication ? 0 : 60000 # default, 1 min
     apply_method = "pending-reboot"
   }
+
+  parameter {
+    name         = "wal_buffers"
+    value        = -1 # this should be default, but apparently its not on AWS RDS https://postgresqlco.nf/doc/en/param/wal_buffers/
+    apply_method = "pending-reboot"
+  }
 }
 
 resource "aws_db_parameter_group" "postgres14" {
@@ -50,6 +56,12 @@ resource "aws_db_parameter_group" "postgres14" {
   parameter {
     name         = "wal_sender_timeout"
     value        = var.enable_replication ? 0 : 60000 # default, 1 min
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "wal_buffers"
+    value        = -1
     apply_method = "pending-reboot"
   }
 }


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

Set parameter to default as is also recommended by Fivetran.

#### Motivation

<img width="661" alt="image" src="https://user-images.githubusercontent.com/5564952/188455229-fcde7c51-5325-4be7-9eaa-cd06de42b1d4.png">

#### Test plan

<!-- How did you test this change? What were you unable to test? Reference automated tests or describe a manual test plan and confirm the outcome. Please keep security and your reviewer in mind. -->

#### Rollout/monitoring/revert plan

<!-- Can this change be reverted? Could it impact our users? -->
