### PR TITLE
Move app cluster mode value into a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 This project does not follow SemVer, since modules are independent of each other; thus, SemVer does not make sense. Changes are grouped per module.
 
 ## [unreleased]
+## Elasticache
+- set `cluster_mode` and `maxmemory_policy` as variables instead of hardcore values.
+- increase default value for `node_count` to comply with default value of `failover`
+
 ## RDS
 - set replacement of non-alphanumeric chars with underscore on RDS DBName value to avoid naming validation errors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ This project does not follow SemVer, since modules are independent of each other
 
 ## [unreleased]
 ## Elasticache
-- set `cluster_mode` and `maxmemory_policy` as variables instead of hardcore values.
-- increase default value for `node_count` to comply with default value of `failover`
+- set `cluster_mode`, `maxmemory_policy`, `elasticache_node_count`, `elasticache_automatic_failover_enabled` as variables instead of hardcore values.
 
 ## RDS
 - set replacement of non-alphanumeric chars with underscore on RDS DBName value to avoid naming validation errors.

--- a/certificate/README.md
+++ b/certificate/README.md
@@ -12,7 +12,7 @@ Thus, creating those will fail if the certificate has not been validated (manual
 ## Usage
 
 ```terraform
-# :warning: MUST be created and manually validated before any depending ressources
+# :warning: MUST be created and manually validated before any depending resources
 module "certificate" {
   source = "github.com/dbl-works/terraform//certificate?ref=v2021.07.05"
 

--- a/elasticache/variables.tf
+++ b/elasticache/variables.tf
@@ -25,7 +25,7 @@ variable "node_type" { default = "cache.t3.micro" }
 
 variable "node_count" {
   type        = number
-  default     = 2
+  default     = 1
   description = "Only required when cluster mode is disabled"
 }
 

--- a/elasticache/variables.tf
+++ b/elasticache/variables.tf
@@ -25,7 +25,7 @@ variable "node_type" { default = "cache.t3.micro" }
 
 variable "node_count" {
   type        = number
-  default     = 1
+  default     = 2
   description = "Only required when cluster mode is disabled"
 }
 

--- a/stack/app/elasticache.tf
+++ b/stack/app/elasticache.tf
@@ -21,5 +21,6 @@ module "elasticache" {
   replicas_per_node_group = var.elasticache_replicas_per_node_group
   shard_count             = var.elasticache_shards_per_replication_group
   parameter_group_name    = var.elasticache_parameter_group_name
-  cluster_mode            = true
+  cluster_mode            = var.elasticache_cluster_mode
+  maxmemory_policy        = var.elasticache_maxmemory_policy == null ? (var.elasticache_cluster_mode == false ? "noeviction" : null) : var.elasticache_maxmemory_policy
 }

--- a/stack/app/elasticache.tf
+++ b/stack/app/elasticache.tf
@@ -13,10 +13,12 @@ module "elasticache" {
   ])))
 
   # optional
-  node_type                = var.elasticache_node_type
-  snapshot_retention_limit = var.elasticache_snapshot_retention_limit
-  data_tiering_enabled     = var.elasticache_data_tiering_enabled
-  multi_az_enabled         = var.elasticache_multi_az_enabled
+  node_type                  = var.elasticache_node_type
+  node_count                 = var.elasticache_node_count == null ? (var.elasticache_automatic_failover_enabled == true ? 2 : 1) : var.elasticache_node_count
+  snapshot_retention_limit   = var.elasticache_snapshot_retention_limit
+  data_tiering_enabled       = var.elasticache_data_tiering_enabled
+  multi_az_enabled           = var.elasticache_multi_az_enabled
+  automatic_failover_enabled = var.elasticache_automatic_failover_enabled
 
   replicas_per_node_group = var.elasticache_replicas_per_node_group
   shard_count             = var.elasticache_shards_per_replication_group

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -133,6 +133,16 @@ variable "elasticache_snapshot_retention_limit" {
   type    = number
   default = 0
 }
+
+variable "elasticache_cluster_mode" {
+  type    = bool
+  default = true
+}
+
+variable "elasticache_maxmemory_policy" {
+  type    = string
+  default = null
+}
 # =============== Elasticache ================ #
 
 # =============== RDS ================ #

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -102,6 +102,11 @@ variable "elasticache_node_type" {
   default = "cache.t3.micro"
 }
 
+variable "elasticache_node_count" {
+  type    = number
+  default = 1
+}
+
 variable "elasticache_parameter_group_name" {
   type    = string
   default = "default.redis6.x.cluster.on"
@@ -142,6 +147,11 @@ variable "elasticache_cluster_mode" {
 variable "elasticache_maxmemory_policy" {
   type    = string
   default = null
+}
+
+variable "elasticache_automatic_failover_enabled" {
+  type    = bool
+  default = true
 }
 # =============== Elasticache ================ #
 


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

<!-- What does the code do? What have you changed? Consider adding before/after screenshots or command line logs. What is the current behavior? What is the expected behavior? -->
it
1. Moves elasticate cluster_mode & maxmemory_policy values into variables in order to allow non-cluster mode Redis setup
2. Increases elasticache node_count to 2 as required for default failover mode.

#### Motivation

<!-- Why are you making this change? Can be a link to a Clubhouse task. -->
https://app.shortcut.com/lih/story/30676/move-lufthansa-flightpass-lhfp-staging-from-heroku-to-aws-ecs-cw37

#### Test plan

<!-- How did you test this change? What were you unable to test? Reference automated tests or describe a manual test plan and confirm the outcome. Please keep security and your reviewer in mind. -->

try to setup
or you can to [this branch](https://github.com/lh-innovationhub/lufthansa-flightpass/pull/882) and see `terraform state list` results


#### Rollout/monitoring/revert plan

<!-- Can this change be reverted? Could it impact our users? -->

git revert
