### PR TITLE
allow passing path to custom lambda & improve query id regex

### DIFF
--- a/cloudwatch-snowflake/README.md
+++ b/cloudwatch-snowflake/README.md
@@ -65,8 +65,10 @@ module "metrics" {
   ]
 
   # optional
-  aws_region_code = "us-east-1" # lambda's aws region
+  aws_region_code         = "us-east-1" # lambda's aws region
   fivetran_aws_account_id = "834469178297" # Fivetran AWS account ID. We need to allow this account to access our lambda function.
-  lambda_role_arn  = "arn:aws:iam::123456789:role/fivetran_lambda" # Lambda role created for connecting the fivetran and lambda. Reuse the same role if you already have it created.
+  lambda_role_arn         = "arn:aws:iam::123456789:role/fivetran_lambda" # Lambda role created for connecting the fivetran and lambda. Reuse the same role if you already have it created.
+  lambda_source_dir       = "${path.module}/tracker"
+  lambda_output_path      = "${path.module}/dist/tracker.zip"
 }
 ```

--- a/cloudwatch-snowflake/main.tf
+++ b/cloudwatch-snowflake/main.tf
@@ -1,7 +1,7 @@
 data "archive_file" "zip" {
   type        = "zip"
-  source_dir  = "${path.module}/tracker"
-  output_path = "${path.module}/dist/tracker.zip"
+  source_dir  = var.lambda_source_dir == null ? "${path.module}/tracker" : var.lambda_source_dir
+  output_path = var.lambda_output_path == null ? "${path.module}/dist/tracker.zip" : var.lambda_output_path
 }
 
 resource "aws_lambda_function" "cloudwatch_metrics_tracker" {

--- a/cloudwatch-snowflake/tracker/index.js
+++ b/cloudwatch-snowflake/tracker/index.js
@@ -1,7 +1,7 @@
 const fivetran = require('./utils/fivetran');
 const cloudwatch = require('./utils/cloudwatch');
 
-exports.handler = async (request, context, callback) => {
+exports.handler = async (request, _context, _callback) => {
   const newRecords = await cloudwatch.getCloudwatchData()
 
   return fivetran.setupFivetranResponse({

--- a/cloudwatch-snowflake/tracker/utils/cloudwatch.js
+++ b/cloudwatch-snowflake/tracker/utils/cloudwatch.js
@@ -14,8 +14,9 @@ const PERCENTILES = [
   'p50'
 ]
 
+// expected pattern: ^[a-z][a-zA-Z0-9_]*$
 const formatQueryId = (name) => {
-  return name.replace(/-|\//g, '_')
+  return name.replace(/-|\/|\./g, '_')
 }
 
 const ecsMetricQueries = ({ serviceName, clusterName, projectName, environment }) => {
@@ -46,7 +47,7 @@ const ecsMetricQueries = ({ serviceName, clusterName, projectName, environment }
 
 const responseTimesQueries = ({ projectName, loadBalancerName, environment }) => {
   return PERCENTILES.map(percentile => ({
-    Id: `${percentile}_${formatQueryId(loadBalancerName)}_${projectName}_${environment}`, /* /^[a-z][a-zA-Z0-9_]*$./ */
+    Id: `${formatQueryId(percentile)}_${formatQueryId(loadBalancerName)}_${projectName}_${environment}`, /* /^[a-z][a-zA-Z0-9_]*$./ */
     MetricStat: {
       Metric: {
         Dimensions: [

--- a/cloudwatch-snowflake/tracker/utils/cloudwatch.js
+++ b/cloudwatch-snowflake/tracker/utils/cloudwatch.js
@@ -16,7 +16,7 @@ const PERCENTILES = [
 
 // expected pattern: ^[a-z][a-zA-Z0-9_]*$
 const formatQueryId = (name) => {
-  return name.replace(/-|\/|\./g, '_')
+  return name.replace(/-|\/|\./g, '_').toLowerCase()
 }
 
 const ecsMetricQueries = ({ serviceName, clusterName, projectName, environment }) => {

--- a/cloudwatch-snowflake/variables.tf
+++ b/cloudwatch-snowflake/variables.tf
@@ -1,3 +1,15 @@
+variable "lambda_source_dir" {
+  type        = string
+  description = "Path to the directory containing the lambda function code"
+  default     = null
+}
+
+variable "lambda_output_path" {
+  type        = string
+  description = "Path to output the zipped lambda function code"
+  default     = null
+}
+
 variable "fivetran_group_id" {
   type        = string
   description = "Also know as external_id. Understand the group concept here: https://fivetran.com/docs/getting-started/powered-by-fivetran#createagroupusingtheui"


### PR DESCRIPTION
In case we need to deploy different lambdas across multiple regions, this change allows us to do so

Also, if the stats is `Maximum` or `p99.9` the current regex to clean the Query Id name was insuffcient.


<img width="812" alt="image" src="https://user-images.githubusercontent.com/20702503/193299756-0232b986-71e1-469d-a5f5-570c887a5077.png">

