### PR TITLE
chore: Refactoring 

### DIFF
--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -46,6 +46,12 @@ module "cloudflare" {
   # optional
   bastion_enabled    = false # set to true if required
   bastion_public_dns = "project-staging-xxxxx.nlb.eu-central-1.amazonaws.com"
+  tls_settings = {
+    tls_1_3                  = "on"
+    automatic_https_rewrites = "on"
+    ssl                      = "strict"
+    always_use_https         = "on"
+  }
 }
 ```
 

--- a/cloudflare/main.tf
+++ b/cloudflare/main.tf
@@ -25,7 +25,7 @@ resource "cloudflare_record" "bastion" {
 # cdn.my-project.com to the S3-Bucket -> e.g. folder "public"
 # app.my-project.com to the S3-Bucket -> e.g. folder "app"
 resource "cloudflare_record" "s3" {
-  for_each = toset(["cdn", "app"])
+  for_each = var.s3_cloudflare_records
 
   zone_id = data.cloudflare_zone.default.id
   name    = each.key
@@ -34,14 +34,10 @@ resource "cloudflare_record" "s3" {
   proxied = true
 }
 
-resource "cloudflare_worker_route" "cdn_route" {
-  zone_id     = data.cloudflare_zone.default.id
-  pattern     = "*cdn.${var.domain}/*"
-  script_name = var.cdn_worker_script_name
-}
+resource "cloudflare_worker_route" "route" {
+  for_each = var.s3_cloudflare_records
 
-resource "cloudflare_worker_route" "app_route" {
   zone_id     = data.cloudflare_zone.default.id
-  pattern     = "*app.${var.domain}/*"
-  script_name = var.app_worker_script_name
+  pattern     = "*${data.key}.${var.domain}/*"
+  script_name = data.value.worker_script_name
 }

--- a/cloudflare/main.tf
+++ b/cloudflare/main.tf
@@ -38,6 +38,6 @@ resource "cloudflare_worker_route" "route" {
   for_each = var.s3_cloudflare_records
 
   zone_id     = data.cloudflare_zone.default.id
-  pattern     = "*${data.key}.${var.domain}/*"
-  script_name = data.value.worker_script_name
+  pattern     = "*${each.key}.${var.domain}/*"
+  script_name = each.value.worker_script_name
 }

--- a/cloudflare/tls.tf
+++ b/cloudflare/tls.tf
@@ -4,13 +4,13 @@
 # 2. terraform apply
 # https://github.com/cloudflare/terraform-provider-cloudflare/issues/808
 resource "cloudflare_zone_settings_override" "tls" {
-  count   = var.https_enabled ? 1 : 0
+  count   = var.tls_settings == null ? 0 : 1
   zone_id = data.cloudflare_zone.default.id
 
   settings {
-    tls_1_3                  = "on"
-    automatic_https_rewrites = "on"
-    ssl                      = "strict"
-    always_use_https         = "on"
+    tls_1_3                  = var.tls_settings.tls_1_3
+    automatic_https_rewrites = var.tls_settings.automatic_https_rewrites
+    ssl                      = var.tls_settings.ssl
+    always_use_https         = var.tls_settings.always_use_https
   }
 }

--- a/cloudflare/tls.tf
+++ b/cloudflare/tls.tf
@@ -1,0 +1,16 @@
+# If you came across this error:
+# Error: invalid zone setting "cname_flattening" (value: ) found - cannot be set as it is read only
+# 1. terraform state rm module.<module-name>.cloudflare_zone_settings_override.tls
+# 2. terraform apply
+# https://github.com/cloudflare/terraform-provider-cloudflare/issues/808
+resource "cloudflare_zone_settings_override" "tls" {
+  count   = var.https_enabled ? 1 : 0
+  zone_id = data.cloudflare_zone.default.id
+
+  settings {
+    tls_1_3                  = "on"
+    automatic_https_rewrites = "on"
+    ssl                      = "strict"
+    always_use_https         = "on"
+  }
+}

--- a/cloudflare/variables.tf
+++ b/cloudflare/variables.tf
@@ -16,10 +16,17 @@ variable "alb_dns_name" {
   type = string
 }
 
-variable "cdn_worker_script_name" {
-  type = string
-}
-
-variable "app_worker_script_name" {
-  type = string
+variable "s3_cloudflare_records" {
+  # {
+  #   cdn = {
+  #     worker_script_name = "serve-cdn"
+  #   },
+  #   app = {
+  #     worker_script_name = "serve-app"
+  #   }
+  # }
+  type = map(object({
+    worker_script_name = string
+  }))
+  default = {}
 }

--- a/cloudflare/variables.tf
+++ b/cloudflare/variables.tf
@@ -12,9 +12,14 @@ variable "bastion_enabled" {
   default = false
 }
 
-variable "https_enabled" {
-  type    = bool
-  default = false
+variable "tls_settings" {
+  type = object({
+    tls_1_3                  = string # "on/off"
+    automatic_https_rewrites = string # "on/off"
+    ssl                      = string # "strict"
+    always_use_https         = string # "on/off"
+  })
+  default = null
 }
 
 variable "alb_dns_name" {

--- a/cloudflare/variables.tf
+++ b/cloudflare/variables.tf
@@ -12,6 +12,11 @@ variable "bastion_enabled" {
   default = false
 }
 
+variable "https_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "alb_dns_name" {
   type = string
 }

--- a/elasticache/outputs.tf
+++ b/elasticache/outputs.tf
@@ -1,6 +1,6 @@
 output "endpoint" {
   description = "The endpoint of the primary node in this node group (shard)"
-  value       = var.cluster_mode ? aws_elasticache_replication_group.cluster_mode[*].primary_endpoint_address : aws_elasticache_replication_group.non_cluster_mode[*].primary_endpoint_address
+  value       = var.cluster_mode ? aws_elasticache_replication_group.cluster_mode[*].configuration_endpoint_address : aws_elasticache_replication_group.non_cluster_mode[*].primary_endpoint_address
 }
 
 output "cluster_name" {

--- a/stack/README.md
+++ b/stack/README.md
@@ -10,6 +10,7 @@ Pre-requirements:
 (1) In order to perform actions in cloudflare, you would need to create api token with at least the following permissions:
   - Zone | DNS | Edit
   - Zone | Worker Routes | Edit
+  - Zone | Zone Settings | Edit
 in the Zone Resources
   - Include | Specific Zone | <Your Zone>
 

--- a/stack/README.md
+++ b/stack/README.md
@@ -6,6 +6,12 @@ This includes:
 - ECR, SSL certificates, secrets, RDS, ECS cluster, S3 buckets,..
 - Cloudflare configuration to route `app.dbl.one` to the bucket's assets, setup DNS records for the app and api, ...
 
+Pre-requirements:
+(1) In order to perform actions in cloudflare, you would need to create api token with at least the following permissions:
+  - Zone | DNS | Edit
+  - Zone | Worker Routes | Edit
+in the Zone Resources
+  - Include | Specific Zone | <Your Zone>
 
 Launching a stack is a three-phase process:
 (1) create all resources from [core](core/README.md) once per project (regardless of the number of environments/clusters).

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -45,6 +45,12 @@ module "stack" {
   skip_cloudflare = false # Skip the creation of cloudflare modules
   cdn_worker_script_name = "serve-cdn"
   app_worker_script_name = "serve-app"
+  tls_settings = {
+    tls_1_3                  = "on"
+    automatic_https_rewrites = "on"
+    ssl                      = "strict"
+    always_use_https         = "on"
+  }
 
   # S3 Private
   private_buckets_list = [

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -41,11 +41,12 @@ module "stack" {
   ]
 
   # Optional
-  region          = "eu-central-1"
-  skip_cloudflare = false
+  region          = "eu-central-1" # Region to deploy the resources
+  skip_cloudflare = false # Skip the creation of cloudflare modules
 
   # S3 Private
   private_buckets_list = [
+    # Example of S3 bucket with replicas
     {
       bucket_name                     = "project-staging-apps",
       versioning                      = true,
@@ -59,6 +60,7 @@ module "stack" {
         }
       ]
     },
+    # Example of S3 bucket without replicas
     {
       bucket_name = "project-staging-reports",
       versioning = false,
@@ -105,6 +107,7 @@ module "stack" {
   # ECS
   allow_internal_traffic_to_ports = []
   allowlisted_ssh_ips             = []
+  # ECS access has been given to the private S3 bucket created in the stack module
   grant_read_access_to_s3_arns    = []
   grant_write_access_to_s3_arns   = []
   grant_read_access_to_sqs_arns   = []
@@ -192,6 +195,10 @@ module "stack" {
   elasticache_parameter_group_name          = "default.redis6.x.cluster.on" # "default.redis6.x" for non-cluster mode
   elasticache_data_tiering_enabled          = false # see the README in the Elasticache Module
   elasticache_multi_az_enabled              = true
+  elasticache_maxmemory_policy              = "noeviction"
+  elasticache_cluster_mode                  = false
+  elasticache_automatic_failover_enabled    = true
+  elasticache_node_count                    = 1
 
   # vpc
   vpc_cidr_block     = "10.0.0.0/16"

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -43,6 +43,8 @@ module "stack" {
   # Optional
   region          = "eu-central-1" # Region to deploy the resources
   skip_cloudflare = false # Skip the creation of cloudflare modules
+  cdn_worker_script_name = "serve-cdn"
+  app_worker_script_name = "serve-app"
 
   # S3 Private
   private_buckets_list = [

--- a/stack/app/cloudflare.tf
+++ b/stack/app/cloudflare.tf
@@ -13,5 +13,6 @@ module "cloudflare" {
 
   # optional
   bastion_enabled    = true
+  https_enabled      = var.https_enabled
   bastion_public_dns = module.ecs.nlb_dns_name
 }

--- a/stack/app/cloudflare.tf
+++ b/stack/app/cloudflare.tf
@@ -13,6 +13,6 @@ module "cloudflare" {
 
   # optional
   bastion_enabled    = true
-  https_enabled      = var.https_enabled
+  tls_settings       = var.tls_settings
   bastion_public_dns = module.ecs.nlb_dns_name
 }

--- a/stack/app/cloudflare.tf
+++ b/stack/app/cloudflare.tf
@@ -9,8 +9,8 @@ module "cloudflare" {
 
   domain                 = var.domain_name
   alb_dns_name           = module.ecs.alb_dns_name
-  cdn_worker_script_name = "serve-cdn"
-  app_worker_script_name = "serve-app"
+  cdn_worker_script_name = var.cdn_worker_script_name
+  app_worker_script_name = var.app_worker_script_name
 
   # optional
   bastion_enabled    = true

--- a/stack/app/cloudflare.tf
+++ b/stack/app/cloudflare.tf
@@ -7,10 +7,9 @@ module "cloudflare" {
     module.s3-frontend,
   ]
 
-  domain                 = var.domain_name
-  alb_dns_name           = module.ecs.alb_dns_name
-  cdn_worker_script_name = var.cdn_worker_script_name
-  app_worker_script_name = var.app_worker_script_name
+  domain                = var.domain_name
+  alb_dns_name          = module.ecs.alb_dns_name
+  s3_cloudflare_records = var.s3_cloudflare_records
 
   # optional
   bastion_enabled    = true

--- a/stack/app/elasticache.tf
+++ b/stack/app/elasticache.tf
@@ -14,7 +14,7 @@ module "elasticache" {
 
   # optional
   node_type                  = var.elasticache_node_type
-  node_count                 = var.elasticache_node_count == null ? (var.elasticache_automatic_failover_enabled == true ? 2 : 1) : var.elasticache_node_count
+  node_count                 = var.elasticache_node_count == null ? (var.elasticache_automatic_failover_enabled ? 2 : 1) : var.elasticache_node_count
   snapshot_retention_limit   = var.elasticache_snapshot_retention_limit
   data_tiering_enabled       = var.elasticache_data_tiering_enabled
   multi_az_enabled           = var.elasticache_multi_az_enabled
@@ -24,5 +24,5 @@ module "elasticache" {
   shard_count             = var.elasticache_shards_per_replication_group
   parameter_group_name    = var.elasticache_parameter_group_name
   cluster_mode            = var.elasticache_cluster_mode
-  maxmemory_policy        = var.elasticache_maxmemory_policy == null ? (var.elasticache_cluster_mode == false ? "noeviction" : null) : var.elasticache_maxmemory_policy
+  maxmemory_policy        = var.elasticache_maxmemory_policy == null ? (var.elasticache_cluster_mode ? null : "noeviction") : var.elasticache_maxmemory_policy
 }

--- a/stack/app/outputs.tf
+++ b/stack/app/outputs.tf
@@ -63,3 +63,7 @@ output "ecs_cluster_name" {
 output "alb_arn_suffix" {
   value = module.ecs.alb_arn_suffix
 }
+
+output "alb_dns_name" {
+  value = module.ecs.alb_dns_name
+}

--- a/stack/app/sample.env
+++ b/stack/app/sample.env
@@ -24,7 +24,6 @@ export TF_VAR_grant_write_access_to_s3_arns=
 export TF_VAR_grant_read_access_to_sqs_arns=
 export TF_VAR_grant_write_access_to_sqs_arns=
 export TF_VAR_ecs_custom_policies=
-export CLOUDFLARE_EMAIL=
 export CLOUDFLARE_API_TOKEN=
 export AWS_ACCESS_KEY_ID=
 export AWS_SECRET_ACCESS_KEY=

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -26,6 +26,18 @@ variable "skip_cloudflare" {
 }
 # =============== Certificate Manager ================ #
 
+# =============== Cloudflare ================ #
+variable "cdn_worker_script_name" {
+  type    = string
+  default = "serve-cdn"
+}
+
+variable "app_worker_script_name" {
+  type    = string
+  default = "serve-app"
+}
+# =============== Cloudflare ================ #
+
 # =============== S3 private ================ #
 variable "private_buckets_list" {
   default = []
@@ -360,8 +372,8 @@ variable "cloudwatch_cluster_names" {
 
 # https://aws.amazon.com/rds/instance-types/
 variable "db_instance_class_memory_in_gb" {
-  type    = number
-  default = null
+  type        = number
+  default     = null
   description = "Optional. Used for calculating the cloudwatch alarm threshold"
 }
 

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -39,7 +39,11 @@ variable "s3_cloudflare_records" {
       worker_script_name = "serve-app"
     }
   }
+}
 
+variable "https_enabled" {
+  type    = bool
+  default = false
 }
 # =============== Cloudflare ================ #
 

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -360,7 +360,9 @@ variable "cloudwatch_cluster_names" {
 
 # https://aws.amazon.com/rds/instance-types/
 variable "db_instance_class_memory_in_gb" {
-  type = number
+  type    = number
+  default = null
+  description = "Optional. Used for calculating the cloudwatch alarm threshold"
 }
 
 variable "datapoints_to_alarm" {

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -41,9 +41,14 @@ variable "s3_cloudflare_records" {
   }
 }
 
-variable "https_enabled" {
-  type    = bool
-  default = false
+variable "tls_settings" {
+  type = object({
+    tls_1_3                  = string # "on/off"
+    automatic_https_rewrites = string # "on/off"
+    ssl                      = string # "strict"
+    always_use_https         = string # "on/off"
+  })
+  default = null
 }
 # =============== Cloudflare ================ #
 

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -27,14 +27,19 @@ variable "skip_cloudflare" {
 # =============== Certificate Manager ================ #
 
 # =============== Cloudflare ================ #
-variable "cdn_worker_script_name" {
-  type    = string
-  default = "serve-cdn"
-}
+variable "s3_cloudflare_records" {
+  type = map(object({
+    worker_script_name = string
+  }))
+  default = {
+    cdn = {
+      worker_script_name = "serve-cdn"
+    },
+    app = {
+      worker_script_name = "serve-app"
+    }
+  }
 
-variable "app_worker_script_name" {
-  type    = string
-  default = "serve-app"
 }
 # =============== Cloudflare ================ #
 

--- a/stack/setup/README.md
+++ b/stack/setup/README.md
@@ -67,7 +67,6 @@ module "stack-setup" {
 # export AWS_REGION=
 provider "aws" {}
 
-# export CLOUDFLARE_EMAIL=
 # export CLOUDFLARE_API_TOKEN=
 provider "cloudflare" {}
 ```

--- a/stack/setup/README.md
+++ b/stack/setup/README.md
@@ -59,6 +59,17 @@ module "stack-setup" {
   # In case this stack has a read-replica RDS in a different region
   rds_cross_region_kms_key_arn = null
 }
+
+# versions.tf
+
+# export AWS_ACCESS_KEY_ID=
+# export AWS_SECRET_ACCESS_KEY=
+# export AWS_REGION=
+provider "aws" {}
+
+# export CLOUDFLARE_EMAIL=
+# export CLOUDFLARE_API_TOKEN=
+provider "cloudflare" {}
 ```
 
 ```terraform

--- a/stack/setup/cloudflare.tf
+++ b/stack/setup/cloudflare.tf
@@ -35,7 +35,7 @@ resource "aws_acm_certificate_validation" "default" {
 }
 
 resource "cloudflare_zone_settings_override" "tls" {
-  name = data.cloudflare_zone.default.id
+  zone_id = data.cloudflare_zone.default.id
 
   settings {
     tls_1_3                  = "on"

--- a/stack/setup/cloudflare.tf
+++ b/stack/setup/cloudflare.tf
@@ -33,18 +33,3 @@ resource "aws_acm_certificate_validation" "default" {
   certificate_arn         = aws_acm_certificate.main.arn
   validation_record_fqdns = cloudflare_record.validation.*.hostname
 }
-
-# If you came across this error:
-# Error: invalid zone setting "cname_flattening" (value: ) found - cannot be set as it is read only
-# 1. terraform state rm module.<module-name>.cloudflare_zone_settings_override.tls
-# 2. terraform apply
-# https://github.com/cloudflare/terraform-provider-cloudflare/issues/808
-resource "cloudflare_zone_settings_override" "tls" {
-  zone_id = data.cloudflare_zone.default.id
-
-  settings {
-    tls_1_3                  = "on"
-    automatic_https_rewrites = "on"
-    ssl                      = "strict"
-  }
-}

--- a/stack/setup/cloudflare.tf
+++ b/stack/setup/cloudflare.tf
@@ -34,6 +34,11 @@ resource "aws_acm_certificate_validation" "default" {
   validation_record_fqdns = cloudflare_record.validation.*.hostname
 }
 
+# If you came across this error:
+# Error: invalid zone setting "cname_flattening" (value: ) found - cannot be set as it is read only
+# 1. terraform state rm module.<module-name>.cloudflare_zone_settings_override.tls
+# 2. terraform apply
+# https://github.com/cloudflare/terraform-provider-cloudflare/issues/808
 resource "cloudflare_zone_settings_override" "tls" {
   zone_id = data.cloudflare_zone.default.id
 

--- a/stack/setup/cloudflare.tf
+++ b/stack/setup/cloudflare.tf
@@ -10,26 +10,36 @@ locals {
   )
 }
 
-# data "cloudflare_zone" "default" {
-#   name = var.domain
-# }
+data "cloudflare_zone" "default" {
+  name = var.domain
+}
 
-# # domain validation
-# resource "cloudflare_record" "validation" {
-#   # We assume that a read-replica stack runs on the same domain, hence we skip Cloudflare
-#   count = var.is_read_replica_on_same_domain ? 0 : length(local.distinct_domain_names)
+# domain validation
+resource "cloudflare_record" "validation" {
+  # We assume that a read-replica stack runs on the same domain, hence we skip Cloudflare
+  count = var.is_read_replica_on_same_domain ? 0 : length(local.distinct_domain_names)
 
-#   zone_id = data.cloudflare_zone.default.id
-#   name    = element(local.domain_validation_options, count.index)["resource_record_name"]
-#   type    = element(local.domain_validation_options, count.index)["resource_record_type"]
-#   # ACM DNS validation record returns the value with a trailing dot however the Cloudflare API trims it off.
-#   # https://github.com/cloudflare/terraform-provider-cloudflare/issues/154
-#   value = trimsuffix(element(local.domain_validation_options, count.index)["resource_record_value"], ".")
-# }
+  zone_id = data.cloudflare_zone.default.id
+  name    = element(local.domain_validation_options, count.index)["resource_record_name"]
+  type    = element(local.domain_validation_options, count.index)["resource_record_type"]
+  # ACM DNS validation record returns the value with a trailing dot however the Cloudflare API trims it off.
+  # https://github.com/cloudflare/terraform-provider-cloudflare/issues/154
+  value = trimsuffix(element(local.domain_validation_options, count.index)["resource_record_value"], ".")
+}
 
-# resource "aws_acm_certificate_validation" "default" {
-#   count = var.is_read_replica_on_same_domain ? 0 : 1
+resource "aws_acm_certificate_validation" "default" {
+  count = var.is_read_replica_on_same_domain ? 0 : 1
 
-#   certificate_arn         = aws_acm_certificate.main.arn
-#   validation_record_fqdns = cloudflare_record.validation.*.hostname
-# }
+  certificate_arn         = aws_acm_certificate.main.arn
+  validation_record_fqdns = cloudflare_record.validation.*.hostname
+}
+
+resource "cloudflare_zone_settings_override" "tls" {
+  name = data.cloudflare_zone.default.id
+
+  settings {
+    tls_1_3                  = "on"
+    automatic_https_rewrites = "on"
+    ssl                      = "strict"
+  }
+}

--- a/stack/setup/cloudflare.tf
+++ b/stack/setup/cloudflare.tf
@@ -10,26 +10,26 @@ locals {
   )
 }
 
-data "cloudflare_zone" "default" {
-  name = var.domain
-}
+# data "cloudflare_zone" "default" {
+#   name = var.domain
+# }
 
-# domain validation
-resource "cloudflare_record" "validation" {
-  # We assume that a read-replica stack runs on the same domain, hence we skip Cloudflare
-  count = var.is_read_replica_on_same_domain ? 0 : length(local.distinct_domain_names)
+# # domain validation
+# resource "cloudflare_record" "validation" {
+#   # We assume that a read-replica stack runs on the same domain, hence we skip Cloudflare
+#   count = var.is_read_replica_on_same_domain ? 0 : length(local.distinct_domain_names)
 
-  zone_id = data.cloudflare_zone.default.id
-  name    = element(local.domain_validation_options, count.index)["resource_record_name"]
-  type    = element(local.domain_validation_options, count.index)["resource_record_type"]
-  # ACM DNS validation record returns the value with a trailing dot however the Cloudflare API trims it off.
-  # https://github.com/cloudflare/terraform-provider-cloudflare/issues/154
-  value = trimsuffix(element(local.domain_validation_options, count.index)["resource_record_value"], ".")
-}
+#   zone_id = data.cloudflare_zone.default.id
+#   name    = element(local.domain_validation_options, count.index)["resource_record_name"]
+#   type    = element(local.domain_validation_options, count.index)["resource_record_type"]
+#   # ACM DNS validation record returns the value with a trailing dot however the Cloudflare API trims it off.
+#   # https://github.com/cloudflare/terraform-provider-cloudflare/issues/154
+#   value = trimsuffix(element(local.domain_validation_options, count.index)["resource_record_value"], ".")
+# }
 
-resource "aws_acm_certificate_validation" "default" {
-  count = var.is_read_replica_on_same_domain ? 0 : 1
+# resource "aws_acm_certificate_validation" "default" {
+#   count = var.is_read_replica_on_same_domain ? 0 : 1
 
-  certificate_arn         = aws_acm_certificate.main.arn
-  validation_record_fqdns = cloudflare_record.validation.*.hostname
-}
+#   certificate_arn         = aws_acm_certificate.main.arn
+#   validation_record_fqdns = cloudflare_record.validation.*.hostname
+# }

--- a/stack/setup/sample.env
+++ b/stack/setup/sample.env
@@ -1,7 +1,6 @@
 export TF_VAR_environment=
 export TF_VAR_project=
 export TF_VAR_kms_deletion_window_in_days=
-export CLOUDFLARE_EMAIL=
 export CLOUDFLARE_API_TOKEN=
 export AWS_ACCESS_KEY_ID=
 export AWS_SECRET_ACCESS_KEY=


### PR DESCRIPTION
#### Summary
- cloudflare: 
  - Allow users to declare the `s3_cloudflare_records` instead of hardcording it to [cdn, app] 
  - Allow user to declare the worker script name
- elasticache:
  - fix cluster mode elasticache endpoint output
- stack/app:
  - Add `alb_dns_name` as output
  - Make `db_instance_class_memory_in_gb` as optional variables
- stack/app
  - Add cloudflare TLS setup   

