### PR TITLE
autoscaling/ecs: Support target response time as ECS autoscaling metrics

### DIFF
--- a/autoscaling/ecs/README.md
+++ b/autoscaling/ecs/README.md
@@ -26,9 +26,18 @@ module "ecs-autoscaling-cpu" {
     {
       metric_name    = "MemoryUtilization"
       statistic      = "Average"
-      threshold_up   = 60
-      threshold_down = 50
-    }
+      threshold_up   = 60 # Optional. If missing, it would not be included in the scale up alarm
+      threshold_down = 50 # Optional. If missing, it would not be included in the scale down alarm
+    },
+    {
+      metric_name  = "TargetResponseTime"
+      statistic    = "p95"
+      threshold_up = 0.130 # in seconds.
+      namespace    = "AWS/ApplicationELB" # Optional value, default value is AWS/ECS
+      dimensions = {
+        LoadBalancer = "app/fb-loadtesting/123456789"
+      } # Optional value, default value is ClusterName/ServiceName
+    },
   ]
 
   # Optional

--- a/autoscaling/ecs/alarms.tf
+++ b/autoscaling/ecs/alarms.tf
@@ -3,7 +3,7 @@ locals {
     for metric in var.autoscale_metrics : metric if metric.threshold_up != null
   ]
   scale_up_expression = join(" || ", [
-    for metric in var.scale_up_metrics : "${lower(metric.metric_name)} > ${metric.threshold_up}"
+    for metric in local.scale_up_metrics : "${lower(metric.metric_name)} > ${metric.threshold_up}"
     ]
   )
 
@@ -11,7 +11,7 @@ locals {
     for metric in var.autoscale_metrics : metric if metric.threshold_down != null
   ]
   scale_down_expression = join(" || ", [
-    for metric in var.scale_down_metrics : "${lower(metric.metric_name)} < ${metric.threshold_down}"
+    for metric in local.scale_down_metrics : "${lower(metric.metric_name)} < ${metric.threshold_down}"
     ]
   )
 
@@ -19,7 +19,7 @@ locals {
 }
 
 resource "aws_cloudwatch_metric_alarm" "scale_up_alarm" {
-  count               = length(var.scale_up_metrics) > 0 ? 1 : 0
+  count               = length(local.scale_up_metrics) > 0 ? 1 : 0
   alarm_name          = "ECS-${var.ecs_cluster_name}-${var.ecs_service_name}-ScaleUpAlarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = var.alarm_evaluation_periods
@@ -34,7 +34,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_up_alarm" {
   }
 
   dynamic "metric_query" {
-    for_each = { for metric in var.scale_up_metrics : metric.metric_name => metric }
+    for_each = { for metric in local.scale_up_metrics : metric.metric_name => metric }
     content {
       id = lower(metric_query.key)
 
@@ -60,7 +60,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_up_alarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "scale_down_alarm" {
-  count               = length(var.scale_down_metrics) > 0 ? 1 : 0
+  count               = length(local.scale_down_metrics) > 0 ? 1 : 0
   alarm_name          = "ECS-${var.ecs_cluster_name}-${var.ecs_service_name}-ScaleDownAlarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = var.alarm_evaluation_periods
@@ -77,7 +77,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_down_alarm" {
   }
 
   dynamic "metric_query" {
-    for_each = { for metric in var.scale_down_metrics : metric.metric_name => metric }
+    for_each = { for metric in local.scale_down_metrics : metric.metric_name => metric }
     content {
       id = lower(metric_query.key)
 

--- a/autoscaling/ecs/alarms.tf
+++ b/autoscaling/ecs/alarms.tf
@@ -77,7 +77,8 @@ resource "aws_cloudwatch_metric_alarm" "scale_down_alarm" {
   }
 
   dynamic "metric_query" {
-    for_each = { for metric in local.scale_down_metrics : metric.metric_name => metric }
+    # Include all metrics here so less_than_threshold_up_expression would not throw error due to missing metrics
+    for_each = { for metric in var.autoscale_metrics : metric.metric_name => metric }
     content {
       id = lower(metric_query.key)
 

--- a/autoscaling/ecs/variables.tf
+++ b/autoscaling/ecs/variables.tf
@@ -89,8 +89,8 @@ variable "autoscale_metrics" {
   type = set(object({
     metric_name    = string                 # Metric which used to decide whether or not to scale in/out
     statistic      = string                 # The statistic to apply to the alarm's associated metric. Supported Argument: SampleCount, Average, Sum, Minimum, Maximum
-    threshold_up   = number                 # Threshold of which ECS should start to scale up
-    threshold_down = optional(number, null) # Threshold of which ECS should start to scale down
+    threshold_up   = optional(number, null) # Threshold of which ECS should start to scale up. If null, would not be included in the scale up alarm
+    threshold_down = optional(number, null) # Threshold of which ECS should start to scale down. If null, would not be included in the scale down alarm
     namespace      = optional(string, "AWS/ECS")
     dimensions     = optional(map(string), {})
   }))

--- a/autoscaling/ecs/variables.tf
+++ b/autoscaling/ecs/variables.tf
@@ -92,7 +92,7 @@ variable "autoscale_metrics" {
     threshold_up   = number                 # Threshold of which ECS should start to scale up
     threshold_down = optional(number, null) # Threshold of which ECS should start to scale down
     namespace      = optional(string, "AWS/ECS")
-    dimensions     = optional(map, {})
+    dimensions     = optional(map(string), {})
   }))
   default = []
 }

--- a/autoscaling/ecs/variables.tf
+++ b/autoscaling/ecs/variables.tf
@@ -87,10 +87,12 @@ variable "ecs_autoscale_role_arn" {
 
 variable "autoscale_metrics" {
   type = set(object({
-    metric_name    = string # Metric which used to decide whether or not to scale in/out
-    statistic      = string # The statistic to apply to the alarm's associated metric. Supported Argument: SampleCount, Average, Sum, Minimum, Maximum
-    threshold_up   = number # Threshold of which ECS should start to scale up
-    threshold_down = number # Threshold of which ECS should start to scale down
+    metric_name    = string                 # Metric which used to decide whether or not to scale in/out
+    statistic      = string                 # The statistic to apply to the alarm's associated metric. Supported Argument: SampleCount, Average, Sum, Minimum, Maximum
+    threshold_up   = number                 # Threshold of which ECS should start to scale up
+    threshold_down = optional(number, null) # Threshold of which ECS should start to scale down
+    namespace      = optional(string, "AWS/ECS")
+    dimensions     = optional(map, {})
   }))
   default = []
 }

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -104,10 +104,12 @@ variable "autoscale_metrics_map" {
     ecs_min_count = optional(number)
     ecs_max_count = optional(number)
     metrics = set(object({
-      metric_name    = string
-      statistic      = string
-      threshold_up   = number
-      threshold_down = number
+      metric_name    = string                 # Metric which used to decide whether or not to scale in/out
+      statistic      = string                 # The statistic to apply to the alarm's associated metric. Supported Argument: SampleCount, Average, Sum, Minimum, Maximum
+      threshold_up   = optional(number, null) # Threshold of which ECS should start to scale up. If null, would not be included in the scale up alarm
+      threshold_down = optional(number, null) # Threshold of which ECS should start to scale down. If null, would not be included in the scale down alarm
+      namespace      = optional(string, "AWS/ECS")
+      dimensions     = optional(map(string), {})
     }))
   }))
   default = {}

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -286,10 +286,12 @@ variable "autoscale_metrics_map" {
     ecs_min_count = optional(number, 1)
     ecs_max_count = optional(number, 30)
     metrics = set(object({
-      metric_name    = string
-      statistic      = string
-      threshold_up   = number
-      threshold_down = number
+      metric_name    = string                 # Metric which used to decide whether or not to scale in/out
+      statistic      = string                 # The statistic to apply to the alarm's associated metric. Supported Argument: SampleCount, Average, Sum, Minimum, Maximum
+      threshold_up   = optional(number, null) # Threshold of which ECS should start to scale up. If null, would not be included in the scale up alarm
+      threshold_down = optional(number, null) # Threshold of which ECS should start to scale down. If null, would not be included in the scale down alarm
+      namespace      = optional(string, "AWS/ECS")
+      dimensions     = optional(map(string), {})
     }))
   }))
   default = {}


### PR DESCRIPTION
#### Summary
Support target response time as ECS autoscaling metrics

#### Motivation
ECS can be scaled up based on the target response time and therefore enhance the user experience time
