### PR TITLE
Allow Creating an ECS Cluster without Secrets/KMS Keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 This project does not follow SemVer, since modules are independent of each other; thus, SemVer does not make sense. Changes are grouped per module.
 
 ## [unreleased]
+## ECS
+- allow creating a cluster without passing secret/KMS key ARN(s)
 
 ## [v2022.09.30]
 ## Elasticache

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -15,10 +15,10 @@ module "ecs" {
   vpc_id             = module.vpc.id
   subnet_private_ids = module.vpc.subnet_private_ids
   subnet_public_ids  = module.vpc.subnet_private_ids
-  secrets_arns       = []
-  kms_key_arns       = []
 
   # optional
+  secrets_arns      = []
+  kms_key_arns      = []
   health_check_path = "/healthz"
   certificate_arn   = module.ssl-certificate.arn # requires a `certificate` module to be created separately
   regional          = true

--- a/ecs/execution-role.tf
+++ b/ecs/execution-role.tf
@@ -167,7 +167,7 @@ resource "aws_iam_role_policy" "ecs-task-execution-secrets-policy" {
           "kms:Decrypt",
           "kms:GenerateDataKey" # for writing to an encrypted S3 bucket
         ],
-        "Resource" : kms_and_secret_arns,
+        "Resource" : length(local.kms_and_secret_arns) > 0 ? kms_and_secret_arns : "can-t-be-blank",
       }
     ]
   }) : []

--- a/ecs/execution-role.tf
+++ b/ecs/execution-role.tf
@@ -153,6 +153,10 @@ locals {
   ])
 }
 
+# Making secret/kms ARNs optional was added later.
+# To avoid a breaking change by introducing a `count` logic (the name would change),
+# we added a dummy policy without any effect instead. AWS performs some validations
+# on policies, hence we can't just use a blank string.
 resource "aws_iam_role_policy" "ecs-task-execution-secrets-policy" {
   name = "ecs-task-execution-secrets-policy"
   role = aws_iam_role.ecs-task-execution.name

--- a/ecs/execution-role.tf
+++ b/ecs/execution-role.tf
@@ -178,7 +178,7 @@ resource "aws_iam_role_policy" "ecs-task-execution-secrets-policy" {
         "Action" : [
           "secretsmanager:GetSecretValue",
         ],
-        "Resource" : "",
+        "Resource" : "arn:aws:secretsmanager:${var.region}:*:secret:can-t-be-blank",
       }
     ]
   })

--- a/ecs/execution-role.tf
+++ b/ecs/execution-role.tf
@@ -167,7 +167,7 @@ resource "aws_iam_role_policy" "ecs-task-execution-secrets-policy" {
           "kms:Decrypt",
           "kms:GenerateDataKey" # for writing to an encrypted S3 bucket
         ],
-        "Resource" : length(local.kms_and_secret_arns) > 0 ? kms_and_secret_arns : "can-t-be-blank",
+        "Resource" : local.kms_and_secret_arns,
       }
     ]
   }) : []

--- a/ecs/execution-role.tf
+++ b/ecs/execution-role.tf
@@ -170,5 +170,5 @@ resource "aws_iam_role_policy" "ecs-task-execution-secrets-policy" {
         "Resource" : local.kms_and_secret_arns,
       }
     ]
-  }) : []
+  }) : ""
 }

--- a/ecs/execution-role.tf
+++ b/ecs/execution-role.tf
@@ -170,5 +170,14 @@ resource "aws_iam_role_policy" "ecs-task-execution-secrets-policy" {
         "Resource" : local.kms_and_secret_arns,
       }
     ]
-  }) : ""
+    }) : jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Deny",
+        "Action" : [],
+        "Resource" : "",
+      }
+    ]
+  })
 }

--- a/ecs/execution-role.tf
+++ b/ecs/execution-role.tf
@@ -175,7 +175,9 @@ resource "aws_iam_role_policy" "ecs-task-execution-secrets-policy" {
     "Statement" : [
       {
         "Effect" : "Deny",
-        "Action" : [],
+        "Action" : [
+          "secretsmanager:GetSecretValue",
+        ],
         "Resource" : "",
       }
     ]

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -31,8 +31,14 @@ variable "subnet_private_ids" { type = list(string) }
 variable "subnet_public_ids" { type = list(string) }
 
 # Allow containers to access the following resources from inside the cluster
-variable "secrets_arns" { type = list(string) }
-variable "kms_key_arns" { type = list(string) }
+variable "secrets_arns" {
+  type    = list(string)
+  default = []
+}
+variable "kms_key_arns" {
+  type    = list(string)
+  default = []
+}
 
 # Sets the certficate for https traffic into the cluster
 # If not passed, no SSL endpoint will be setup


### PR DESCRIPTION
#### Summary

Some simple apps might not need any secrets, thus this allows to launch an ECS Cluster without passing secret ARN(s) and KMS key ARN(s)

#### Motivation

I'm toying with an app that does not need secrets, and I don't want to launch resources that won't be needed.

#### Test plan

<!-- How did you test this change? What were you unable to test? Reference automated tests or describe a manual test plan and confirm the outcome. Please keep security and your reviewer in mind. -->

#### Rollout/monitoring/revert plan

<!-- Can this change be reverted? Could it impact our users? -->
