### PR TITLE
cloudwatch: Add p99 and average to CPU and Memory metrics graph

### DIFF
--- a/cloudwatch/main.tf
+++ b/cloudwatch/main.tf
@@ -143,7 +143,7 @@ locals {
             ["...", { "id" : "m3", "label" : "p99", "stat" : "p99" }],
           ],
           "view" : "timeSeries",
-          "stacked" : true,
+          "stacked" : false,
           "region" : "${var.region}",
           "title" : "Memory Usage",
           "period" : var.metric_period,

--- a/cloudwatch/main.tf
+++ b/cloudwatch/main.tf
@@ -139,7 +139,7 @@ locals {
         "properties" : {
           "metrics" : [
             ["AWS/ECS", "MemoryUtilization", "ServiceName", "web", "ClusterName", name, { "id" : "m1", "label" : "Max", "stat" : "Maximum" }],
-            ["...", { "id" : "m2", "label" : "average", "stat" : "Average" }],
+            ["...", { "id" : "m2", "label" : "Avg", "stat" : "Average" }],
             ["...", { "id" : "m3", "label" : "p99", "stat" : "p99" }],
           ],
           "view" : "timeSeries",
@@ -164,7 +164,7 @@ locals {
         "properties" : {
           "metrics" : [
             ["AWS/ECS", "CPUUtilization", "ServiceName", "web", "ClusterName", name, { "id" : "m1", "label" : "Max", "stat" : "Maximum" }],
-            ["...", { "id" : "m2", "label" : "average", "stat" : "Average" }],
+            ["...", { "id" : "m2", "label" : "Avg", "stat" : "Average" }],
             ["...", { "id" : "m3", "label" : "p99", "stat" : "p99" }],
           ],
           "view" : "timeSeries",

--- a/cloudwatch/main.tf
+++ b/cloudwatch/main.tf
@@ -138,14 +138,15 @@ locals {
         "type" : "metric",
         "properties" : {
           "metrics" : [
-            ["AWS/ECS", "MemoryUtilization", "ServiceName", "web", "ClusterName", name, { "label" : name }]
+            ["AWS/ECS", "MemoryUtilization", "ServiceName", "web", "ClusterName", name, { "id" : "m1", "label" : "Max", "stat" : "Maximum" }],
+            ["...", { "id" : "m2", "label" : "average", "stat" : "Average" }],
+            ["...", { "id" : "m3", "label" : "p99", "stat" : "p99" }],
           ],
           "view" : "timeSeries",
           "stacked" : true,
           "region" : "${var.region}",
           "title" : "Memory Usage",
           "period" : var.metric_period,
-          "stat" : "Maximum",
           "yAxis" : {
             "left" : {
               "min" : 0,
@@ -162,14 +163,15 @@ locals {
         "type" : "metric",
         "properties" : {
           "metrics" : [
-            ["AWS/ECS", "CPUUtilization", "ServiceName", "web", "ClusterName", name, { "label" : name }]
+            ["AWS/ECS", "CPUUtilization", "ServiceName", "web", "ClusterName", name, { "id" : "m1", "label" : "Max", "stat" : "Maximum" }],
+            ["...", { "id" : "m2", "label" : "average", "stat" : "Average" }],
+            ["...", { "id" : "m3", "label" : "p99", "stat" : "p99" }],
           ],
           "view" : "timeSeries",
           "stacked" : false,
           "region" : "${var.region}",
           "title" : "CPU Usage",
           "period" : var.metric_period,
-          "stat" : "Maximum",
           "yAxis" : {
             "left" : {
               "min" : 0,


### PR DESCRIPTION
#### Summary
Add p99 and average to CPU and Memory metrics graph
