### PR TITLE
Support multiple SSL Certificates per ALB (SNI)

### DIFF
--- a/certificate/outputs.tf
+++ b/certificate/outputs.tf
@@ -6,3 +6,7 @@ output "domain_validation_information" {
 output "arn" {
   value = aws_acm_certificate.main.arn
 }
+
+output "domain_name" {
+  value = aws_acm_certificate.main.domain_name
+}

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -21,8 +21,13 @@ module "ecs" {
   kms_key_arns                = []
   health_check_path           = "/healthz"
   certificate_arn             = module.ssl-certificate.arn # requires a `certificate` module to be created separately
-  additional_certificate_arns = [] # Using SNI to attach multiple certificates to the same load balancer
   regional                    = true
+  additional_certificate_arns = [
+    {
+      name = "my-second-domain.test"
+      arn  = module.ssl-certificate-second-domain.arn
+    }
+  ]
 
   allow_internal_traffic_to_ports = []
 

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -17,11 +17,12 @@ module "ecs" {
   subnet_public_ids  = module.vpc.subnet_private_ids
 
   # optional
-  secrets_arns      = []
-  kms_key_arns      = []
-  health_check_path = "/healthz"
-  certificate_arn   = module.ssl-certificate.arn # requires a `certificate` module to be created separately
-  regional          = true
+  secrets_arns                = []
+  kms_key_arns                = []
+  health_check_path           = "/healthz"
+  certificate_arn             = module.ssl-certificate.arn # requires a `certificate` module to be created separately
+  additional_certificate_arns = [] # Using SNI to attach multiple certificates to the same load balancer
+  regional                    = true
 
   allow_internal_traffic_to_ports = []
 

--- a/ecs/alb.tf
+++ b/ecs/alb.tf
@@ -39,4 +39,12 @@ resource "aws_alb_listener" "https" {
     target_group_arn = aws_alb_target_group.ecs.arn
     type             = "forward"
   }
+
+  # Using SNI to attach multiple certificates to the same load balancer
+  resource "aws_alb_listener_certificate" "https" {
+    for_each = var.additional_certificate_arns
+
+    listener_arn    = aws_alb_listener.https.arn
+    certificate_arn = each.value
+  }
 }

--- a/ecs/alb.tf
+++ b/ecs/alb.tf
@@ -43,7 +43,7 @@ resource "aws_alb_listener" "https" {
 
 # Using SNI to attach multiple certificates to the same load balancer
 resource "aws_alb_listener_certificate" "https" {
-  for_each = var.additional_certificate_arns
+  for_each = toset(var.additional_certificate_arns)
 
   listener_arn    = aws_alb_listener.https.arn
   certificate_arn = each.value

--- a/ecs/alb.tf
+++ b/ecs/alb.tf
@@ -46,5 +46,5 @@ resource "aws_alb_listener_certificate" "https" {
   for_each = { for cert in var.additional_certificate_arns : cert.name => cert }
 
   listener_arn    = aws_alb_listener.https.arn
-  certificate_arn = cert.arn
+  certificate_arn = each.value.arn
 }

--- a/ecs/alb.tf
+++ b/ecs/alb.tf
@@ -43,7 +43,7 @@ resource "aws_alb_listener" "https" {
 
 # Using SNI to attach multiple certificates to the same load balancer
 resource "aws_alb_listener_certificate" "https" {
-  for_each = { for cert in var.additional_certificate_arns : cert.name => arn }
+  for_each = { for cert in var.additional_certificate_arns : cert.name => cert }
 
   listener_arn    = aws_alb_listener.https.arn
   certificate_arn = cert.arn

--- a/ecs/alb.tf
+++ b/ecs/alb.tf
@@ -43,8 +43,8 @@ resource "aws_alb_listener" "https" {
 
 # Using SNI to attach multiple certificates to the same load balancer
 resource "aws_alb_listener_certificate" "https" {
-  for_each = toset(var.additional_certificate_arns)
+  for_each = { for cert in var.additional_certificate_arns : cert.name => arn }
 
   listener_arn    = aws_alb_listener.https.arn
-  certificate_arn = each.value
+  certificate_arn = cert.arn
 }

--- a/ecs/alb.tf
+++ b/ecs/alb.tf
@@ -39,12 +39,12 @@ resource "aws_alb_listener" "https" {
     target_group_arn = aws_alb_target_group.ecs.arn
     type             = "forward"
   }
+}
 
-  # Using SNI to attach multiple certificates to the same load balancer
-  resource "aws_alb_listener_certificate" "https" {
-    for_each = var.additional_certificate_arns
+# Using SNI to attach multiple certificates to the same load balancer
+resource "aws_alb_listener_certificate" "https" {
+  for_each = var.additional_certificate_arns
 
-    listener_arn    = aws_alb_listener.https.arn
-    certificate_arn = each.value
-  }
+  listener_arn    = aws_alb_listener.https.arn
+  certificate_arn = each.value
 }

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -44,6 +44,11 @@ variable "kms_key_arns" {
 # If not passed, no SSL endpoint will be setup
 variable "certificate_arn" {}
 
+variable "additional_certificate_arns" {
+  type    = list(string)
+  default = []
+}
+
 # CIDR blocks to allow traffic from
 # Setting this will enable NLB traffic
 variable "allowlisted_ssh_ips" {
@@ -52,7 +57,10 @@ variable "allowlisted_ssh_ips" {
 }
 
 # This is where the load balancer will send health check requests to the app containers
-variable "health_check_path" { default = "/healthz" }
+variable "health_check_path" {
+  type    = string
+  default = "/healthz"
+}
 
 variable "grant_read_access_to_s3_arns" {
   default = []

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -45,8 +45,13 @@ variable "kms_key_arns" {
 variable "certificate_arn" {}
 
 variable "additional_certificate_arns" {
-  type    = list(string)
-  default = []
+  description = "Additional certificates to add to the load balancer"
+  default     = []
+
+  type = list(object({
+    name = string
+    arn  = string
+  }))
 }
 
 # CIDR blocks to allow traffic from

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -121,7 +121,12 @@ module "stack" {
   grant_read_access_to_sqs_arns   = []
   grant_write_access_to_sqs_arns  = []
   ecs_custom_policies             = []
-  additional_certificate_arns     = []
+  additional_certificate_arns     = [
+    {
+      name = "my-second-domain.test"
+      arn  = module.ssl-certificate-second-domain.arn
+    }
+  ]
   # This is only needed when we want to add additional secrets to the ECS
   secret_arns                     = []
   # appends region to the name (usually ${project}-${environment}) for globally unique names

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -121,6 +121,7 @@ module "stack" {
   grant_read_access_to_sqs_arns   = []
   grant_write_access_to_sqs_arns  = []
   ecs_custom_policies             = []
+  additional_certificate_arns     = []
   # This is only needed when we want to add additional secrets to the ECS
   secret_arns                     = []
   # appends region to the name (usually ${project}-${environment}) for globally unique names

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -21,11 +21,12 @@ module "ecs" {
   ]))
 
   # optional
-  health_check_path = var.health_check_path
-  certificate_arn   = data.aws_acm_certificate.default.arn
-  regional          = var.regional
-  name              = var.ecs_name # custom name when convention exceeds 32 chars
-  region            = var.region   # used for e.g CloudWatch metrics
+  health_check_path           = var.health_check_path
+  certificate_arn             = data.aws_acm_certificate.default.arn
+  additional_certificate_arns = var.additional_certificate_arns
+  regional                    = var.regional
+  name                        = var.ecs_name # custom name when convention exceeds 32 chars
+  region                      = var.region   # used for e.g CloudWatch metrics
 
   allow_internal_traffic_to_ports = var.allow_internal_traffic_to_ports
 

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -274,6 +274,11 @@ variable "ecs_custom_policies" {
   default = []
 }
 
+variable "additional_certificate_arns" {
+  type    = list(string)
+  default = []
+}
+
 variable "secret_arns" {
   description = "arns of the secret manager that ECS can access"
   default     = []

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -275,8 +275,13 @@ variable "ecs_custom_policies" {
 }
 
 variable "additional_certificate_arns" {
-  type    = list(string)
-  default = []
+  description = "Additional certificates to add to the load balancer"
+  default     = []
+
+  type = list(object({
+    name = string
+    arn  = string
+  }))
 }
 
 variable "secret_arns" {


### PR DESCRIPTION
#### Summary

- Adds Basic SNI Support
- also allow stack to pass additional certificates through

<!-- If this branch is in progress, create a Draft PR. -->
<!-- What does the code do? What have you changed? Consider adding before/after screenshots or command line logs. What is the current behavior? What is the expected behavior? -->

#### Motivation


https://aws.amazon.com/blogs/aws/new-application-load-balancer-sni/
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_certificate

Given a multi-region application, I want to add certificates for
* api.my-app.test
* api.eu-central-1.my-app.test
* api.us-east-1.my-app.test

to test a specific region directly. This is not doable with wildcard certificates due to the usage third level domains.


#### Test plan

Tested here:

https://go/terraform-151-1 # api.my-app.test/healthz
https://go/terraform-151-2 # api.eu-central-1.my-app.test/healthz
https://go/terraform-151-3 # api.us-east-1.my-app.test/healthz


**before**
<img width="1223" alt="image" src="https://user-images.githubusercontent.com/20702503/210167875-82565fcb-480b-4dc9-a394-0f6bc20afe61.png">


#### Rollout/monitoring/revert plan

<!-- Can this change be reverted? Could it impact our users? -->
