### PR TITLE
RDS: Use custom name everywhere if passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 This project does not follow SemVer, since modules are independent of each other; thus, SemVer does not make sense. Changes are grouped per module.
 
 ## [unreleased]
+### RDS
+- consistenly use `local.name` instead of `project-environment`. By default, both are the same, but `local.name` can be overridden to allow for more flexibility; e.g. when one needs to launch multiple RDS instances for the same project/environment.
 
 ## [v2022.12.12]
 ## Autoscaling/ECS

--- a/rds/iam.tf
+++ b/rds/iam.tf
@@ -15,7 +15,7 @@ resource "aws_iam_policy" "rds-db-connect" {
   for_each    = toset(local.db_roles)
   name        = "${local.name}-rds-db-connect-${each.key}"
   path        = "/"
-  description = "Allow connecting as ${each.key} to ${var.project} ${var.environment} (${var.region}) using IAM roles"
+  description = "Allow connecting as ${each.key} to ${local.name} (${var.region}) using IAM roles"
 
   policy = <<EOF
 {
@@ -27,7 +27,7 @@ resource "aws_iam_policy" "rds-db-connect" {
         "rds-db:connect"
       ],
       "Resource": [
-        "arn:aws:rds-db:${var.region}:${var.account_id}:dbuser:${aws_db_instance.main.resource_id}/${var.project}_${var.environment}_${each.key}"
+        "arn:aws:rds-db:${var.region}:${var.account_id}:dbuser:${aws_db_instance.main.resource_id}/${local.name_underscored}_${each.key}"
       ]
     },
     {
@@ -59,7 +59,7 @@ resource "aws_iam_group" "rds-view" {
 resource "aws_iam_policy" "rds-view" {
   name        = "${local.name}-rds-view"
   path        = "/"
-  description = "Allow viewing db instances for ${var.project} ${var.environment}"
+  description = "Allow viewing db instances for ${local.name}"
 
   policy = <<EOF
 {

--- a/rds/iam.tf
+++ b/rds/iam.tf
@@ -3,8 +3,6 @@ locals {
     "admin",
     "readonly",
   ]
-
-  name = var.name != null ? var.name : "${var.project}-${var.environment}${var.regional ? "-${var.region}" : ""}"
 }
 
 # Readonly access to database

--- a/rds/parameter-group.tf
+++ b/rds/parameter-group.tf
@@ -1,5 +1,5 @@
 resource "aws_db_parameter_group" "postgres13" {
-  name   = "${var.project}-${var.environment}-postgres13"
+  name   = "${local.name}-postgres13"
   family = "postgres13"
   parameter {
     name  = "log_statement"
@@ -33,7 +33,7 @@ resource "aws_db_parameter_group" "postgres13" {
 }
 
 resource "aws_db_parameter_group" "postgres14" {
-  name   = "${var.project}-${var.environment}-postgres14"
+  name   = "${local.name}-postgres14"
   family = "postgres14"
   parameter {
     name  = "log_statement"

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -5,7 +5,7 @@ resource "aws_db_instance" "main" {
   engine                              = var.is_read_replica ? null : "postgres"
   engine_version                      = var.is_read_replica ? null : var.engine_version
   instance_class                      = var.instance_class
-  identifier                          = "${var.project}-${var.environment}${var.is_read_replica ? "-read-replica" : ""}"
+  identifier                          = "${local.name}${var.is_read_replica ? "-read-replica" : ""}"
   db_name                             = var.is_read_replica ? null : replace("${var.project}_${var.environment}", "/[^0-9A-Za-z_]/", "_") # name of the initial database
   skip_final_snapshot                 = true
   username                            = var.is_read_replica ? null : var.username # credentials of the master DB are used

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -38,7 +38,7 @@ resource "aws_db_instance" "main" {
   replicate_source_db = var.master_db_instance_arn
 
   tags = {
-    Name        = "${var.project}-${var.environment}"
+    Name        = local.name
     Project     = var.project
     Environment = var.environment
   }

--- a/rds/security-group.tf
+++ b/rds/security-group.tf
@@ -1,9 +1,9 @@
 resource "aws_security_group" "db" {
-  name   = "${var.project}-${var.environment}-db"
+  name   = "${local.name}-db"
   vpc_id = var.vpc_id
 
   tags = {
-    Name        = "${var.project}-${var.environment}-db"
+    Name        = "${local.name}-db"
     Project     = var.project
     Environment = var.environment
   }

--- a/rds/subnet-group.tf
+++ b/rds/subnet-group.tf
@@ -1,9 +1,9 @@
 resource "aws_db_subnet_group" "main" {
-  name       = "${var.project}-${var.environment}"
+  name       = local.name
   subnet_ids = var.subnet_ids
 
   tags = {
-    Name        = "${var.project}-${var.environment}"
+    Name        = local.name
     Project     = var.project
     Environment = var.environment
   }

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -78,3 +78,7 @@ variable "enable_replication" {
   description = "Enables logical replication of the database."
   default     = false
 }
+
+locals {
+  name = var.name != null ? var.name : "${var.project}-${var.environment}${var.regional ? "-${var.region}" : ""}"
+}

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -80,5 +80,6 @@ variable "enable_replication" {
 }
 
 locals {
-  name = var.name != null ? var.name : "${var.project}-${var.environment}${var.regional ? "-${var.region}" : ""}"
+  name             = var.name != null ? var.name : "${var.project}-${var.environment}${var.regional ? "-${var.region}" : ""}"
+  name_underscored = var.name != null ? replace(var.name, "-", "_") : "${var.project}_${var.environment}${var.regional ? "_${var.region}" : ""}"
 }


### PR DESCRIPTION
When adding a 2nd DB to the same environment/project, this currently would fail:

> Error: creating Security Group (dbl-production-db): InvalidGroup.Duplicate: The security group 'dbl-production-db' already exists for VPC 'vpc-09ba3920de77c22f8'
>
> Error: creating DB Parameter Group: DBParameterGroupAlreadyExists: Parameter group dbl-production-postgres13 already exists
>
> Error: creating DB Parameter Group: DBParameterGroupAlreadyExists: Parameter group dbl-production-postgres14 already exists
>
> Error: creating RDS DB Subnet Group (dbl-production): DBSubnetGroupAlreadyExists: The DB subnet group 'dbl-production' already exists.


In the test that resulted in above errors, a `name` was explicitly passed (`"${local.project}-${local.environment}-datascience"`)

