### PR TITLE
[Chore] Support patch version in RDS module

### DIFF
--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -11,7 +11,7 @@ resource "aws_db_instance" "main" {
   username                            = var.is_read_replica ? null : var.username # credentials of the master DB are used
   password                            = var.is_read_replica ? null : var.password # credentials of the master DB are used
   iam_database_authentication_enabled = true
-  parameter_group_name                = var.engine_version == "14" ? aws_db_parameter_group.postgres14.name : aws_db_parameter_group.postgres13.name
+  parameter_group_name                = split(".", var.engine_version)[0] == "14" ? aws_db_parameter_group.postgres14.name : aws_db_parameter_group.postgres13.name
   apply_immediately                   = true
   multi_az                            = var.multi_az
   publicly_accessible                 = var.publicly_accessible


### PR DESCRIPTION
### Descriptions
https://github.com/dbl-works/terraform/blob/main/rds/rds.tf#L14

If we were to specify a minor version, e.g., 14.5 then var.engine_version == "14" would evaluate to "false", and use the v13 parameter group, which then results in an error.

To the user, it is not obvious, that a minor version cannot be specified, especially since passing a minor version is generally supported by RDS.

### Relevant issues
resolves https://github.com/dbl-works/terraform/issues/153