### PR TITLE
Fix: Loggroup name: use local name

### DIFF
--- a/ecs/log-group.tf
+++ b/ecs/log-group.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "ecs-app" {
-  name              = "/ecs/${var.name}"
+  name              = "/ecs/${local.name}"
   retention_in_days = 90
 
   tags = {


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary


var.name may be null, if so, local.name sets a default

#### Motivation

<!-- Why are you making this change? -->
