### PR TITLE
[Chore] Improve the usage of aws_acm_certificates in stack/app and stack/setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ This project does not follow SemVer, since modules are independent of each other
 ### Stack/app
 - Make S3 replicas as optional variables. [#158](https://github.com/dbl-works/terraform/pull/158)
 - Make NAT optional. NAT is not created if `public_ips` is not given. [#164](https://github.com/dbl-works/terraform/pull/164)
+- Add certificate_arn as optional variables. Allows the user to decide which aws acm certificate to be used.[#170](https://github.com/dbl-works/terraform/pull/170)
+
+### Stack/setup
+- Remove the creation of aws_acm_certificate when is_read_replica_on_same_domain is true. [#170](https://github.com/dbl-works/terraform/pull/170)
+- Add cloudflare_validation_hostnames as output.[#170](https://github.com/dbl-works/terraform/pull/170)
 
 ### iam/iam-policy-for-taggable-resources
 - Add BatchGet* and BatchCheck* commands to include the missing read permissions for ECR (e.g. BatchCheckLayerAvailability, BatchGetImage). [#162](https://github.com/dbl-works/terraform/pull/162)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project does not follow SemVer, since modules are independent of each other
 - Make S3 replicas as optional variables. [#158](https://github.com/dbl-works/terraform/pull/158)
 - Make NAT optional. NAT is not created if `public_ips` is not given. [#164](https://github.com/dbl-works/terraform/pull/164)
 - Add certificate_arn as optional variables. Allows the user to decide which aws acm certificate to be used.[#170](https://github.com/dbl-works/terraform/pull/170)
+- Always use the most recent aws_acm_certificate to avoid the multiple certificates error.[#170](https://github.com/dbl-works/terraform/pull/170)
 
 ### Stack/setup
 - Remove the creation of aws_acm_certificate when is_read_replica_on_same_domain is true. [#170](https://github.com/dbl-works/terraform/pull/170)

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -125,6 +125,7 @@ module "stack" {
   grant_read_access_to_sqs_arns   = []
   grant_write_access_to_sqs_arns  = []
   ecs_custom_policies             = []
+  certificate_arn                 = "arn:aws:acm:eu-central-1:xxxxxxxxxxxx:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" # Optional, will use the default cert if it is not provided
   additional_certificate_arns     = [
     {
       name = "my-second-domain.test"

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -1,5 +1,6 @@
 data "aws_acm_certificate" "default" {
   domain = var.domain_name
+  most_recent = true
 }
 
 module "ecs" {

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -22,7 +22,7 @@ module "ecs" {
 
   # optional
   health_check_path           = var.health_check_path
-  certificate_arn             = data.aws_acm_certificate.default.arn
+  certificate_arn             = var.certificate_arn ? var.certificate_arn : data.aws_acm_certificate.default.arn
   additional_certificate_arns = var.additional_certificate_arns
   regional                    = var.regional
   name                        = var.ecs_name # custom name when convention exceeds 32 chars

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -1,5 +1,5 @@
 data "aws_acm_certificate" "default" {
-  domain = var.domain_name
+  domain      = var.domain_name
   most_recent = true
 }
 
@@ -23,7 +23,7 @@ module "ecs" {
 
   # optional
   health_check_path           = var.health_check_path
-  certificate_arn             = var.certificate_arn ? var.certificate_arn : data.aws_acm_certificate.default.arn
+  certificate_arn             = var.certificate_arn == null ? data.aws_acm_certificate.default.arn : var.certificate_arn
   additional_certificate_arns = var.additional_certificate_arns
   regional                    = var.regional
   name                        = var.ecs_name # custom name when convention exceeds 32 chars

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -24,6 +24,11 @@ variable "skip_cloudflare" {
   type    = bool
   default = false
 }
+
+variable "certificate_arn" {
+  type    = string
+  default = null
+}
 # =============== Certificate Manager ================ #
 
 # =============== Cloudflare ================ #

--- a/stack/setup/cloudflare.tf
+++ b/stack/setup/cloudflare.tf
@@ -1,10 +1,10 @@
 locals {
-  distinct_domain_names = distinct(
-    [for s in setunion([var.domain], try(aws_acm_certificate.main[0].subject_alternative_names), []) : replace(s, "*.", "")]
+  distinct_domain_names = var.is_read_replica_on_same_domain ? [] : distinct(
+    [for s in setunion([var.domain], aws_acm_certificate.main[0].subject_alternative_names) : replace(s, "*.", "")]
   )
   # https://github.com/hashicorp/terraform/issues/26043
-  domain_validation_options = distinct(
-    [for k, v in try(aws_acm_certificate.main[0].domain_validation_options, []) : merge(
+  domain_validation_options = var.is_read_replica_on_same_domain ? [] : distinct(
+    [for k, v in aws_acm_certificate.main[0].domain_validation_options : merge(
       tomap(v), { domain_name = replace(v.domain_name, "*.", "") }
     )]
   )

--- a/stack/setup/cloudflare.tf
+++ b/stack/setup/cloudflare.tf
@@ -1,10 +1,10 @@
 locals {
   distinct_domain_names = distinct(
-    [for s in setunion([var.domain], aws_acm_certificate.main.subject_alternative_names) : replace(s, "*.", "")]
+    [for s in setunion([var.domain], aws_acm_certificate.main[0].subject_alternative_names) : replace(s, "*.", "")]
   )
   # https://github.com/hashicorp/terraform/issues/26043
   domain_validation_options = distinct(
-    [for k, v in aws_acm_certificate.main.domain_validation_options : merge(
+    [for k, v in aws_acm_certificate.main[0].domain_validation_options : merge(
       tomap(v), { domain_name = replace(v.domain_name, "*.", "") }
     )]
   )
@@ -30,6 +30,6 @@ resource "cloudflare_record" "validation" {
 resource "aws_acm_certificate_validation" "default" {
   count = var.is_read_replica_on_same_domain ? 0 : 1
 
-  certificate_arn         = aws_acm_certificate.main.arn
+  certificate_arn         = aws_acm_certificate.main[0].arn
   validation_record_fqdns = cloudflare_record.validation.*.hostname
 }

--- a/stack/setup/cloudflare.tf
+++ b/stack/setup/cloudflare.tf
@@ -1,10 +1,10 @@
 locals {
   distinct_domain_names = distinct(
-    [for s in setunion([var.domain], aws_acm_certificate.main[0].subject_alternative_names) : replace(s, "*.", "")]
+    [for s in setunion([var.domain], try(aws_acm_certificate.main[0].subject_alternative_names), []) : replace(s, "*.", "")]
   )
   # https://github.com/hashicorp/terraform/issues/26043
   domain_validation_options = distinct(
-    [for k, v in aws_acm_certificate.main[0].domain_validation_options : merge(
+    [for k, v in try(aws_acm_certificate.main[0].domain_validation_options, []) : merge(
       tomap(v), { domain_name = replace(v.domain_name, "*.", "") }
     )]
   )

--- a/stack/setup/main.tf
+++ b/stack/setup/main.tf
@@ -60,6 +60,8 @@ module "secrets-kms-key" {
 }
 
 resource "aws_acm_certificate" "main" {
+  count = var.is_read_replica_on_same_domain ? 0 : 1
+
   domain_name = var.domain
 
   subject_alternative_names = flatten(concat(

--- a/stack/setup/outputs.tf
+++ b/stack/setup/outputs.tf
@@ -23,3 +23,7 @@ output "eips-nat" {
 output "kms-key-replica-rds-arn" {
   value = var.rds_cross_region_kms_key_arn == null ? "Not applicable if 'rds_cross_region_kms_key_arn' is not set." : join("", module.kms-key-replica-rds.*.arn)
 }
+
+output "cloudflare_validation_hostnames" {
+  value = var.is_read_replica_on_same_domain ? [] : cloudflare_record.validation.*.hostname
+}


### PR DESCRIPTION
#### Summary
### Stack/app
- Add certificate_arn as optional variables. Allows the user to decide which aws acm certificate to be used.
- Always use the most recent aws_acm_certificate to avoid the multiple certificates error.

### Stack/setup
- Remove the creation of aws_acm_certificate when is_read_replica_on_same_domain is true.
- Pass cloudflare_validation_hostnames as output.