### PR TITLE
[Chore] Add ECR lifecycle policy rules to keep at least 1 images on important branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project does not follow SemVer, since modules are independent of each other
 
 ### ecr
 - Add lifecycle policy rules. [#169](https://github.com/dbl-works/terraform/pull/169)
+- Add default lifecycle policy rules to keep at least 1 images on important branchs. [#172](https://github.com/dbl-works/terraform/pull/172)
 
 ## [v2022.12.12]
 ## Autoscaling/ECS

--- a/ecr/README.md
+++ b/ecr/README.md
@@ -14,7 +14,7 @@ module "ecr" {
   # Optional
   mutable = false
   valid_days = 3
-  protected_tags = ["latest-master", "latest-production"] # will keep at least 1 of this tag
+  protected_tags = ["latest-main", "latest-production"] # will keep at least 1 of this tag
   ecr_lifecycle_policy_rules = [
     {
       "rulePriority": 4,

--- a/ecr/README.md
+++ b/ecr/README.md
@@ -12,7 +12,7 @@ module "ecr" {
   project = local.project
 
   # Optional
-  mutable = false # Keep mutable to false for protected tags to work
+  mutable = false # Set mutable to true when using protected tags, so tags like `latest-main` can be overwritten
   valid_days = 3
   protected_tags = ["latest-main", "latest-production"] # will keep at least 1 of this tag
   ecr_lifecycle_policy_rules = [

--- a/ecr/README.md
+++ b/ecr/README.md
@@ -12,7 +12,7 @@ module "ecr" {
   project = local.project
 
   # Optional
-  mutable = false
+  mutable = false # Keep mutable to false for protected tags to work
   valid_days = 3
   protected_tags = ["latest-main", "latest-production"] # will keep at least 1 of this tag
   ecr_lifecycle_policy_rules = [

--- a/ecr/README.md
+++ b/ecr/README.md
@@ -3,7 +3,6 @@
 A repository for storing built docker images.
 
 
-
 ## Usage
 
 ```terraform
@@ -15,9 +14,10 @@ module "ecr" {
   # Optional
   mutable = false
   valid_days = 3
+  protected_tags = ["latest-master", "latest-production"] # will keep at least 1 of this tag
   ecr_lifecycle_policy_rules = [
     {
-      "rulePriority": 2,
+      "rulePriority": 4,
       "description": "Keep last 30 images",
       "selection": {
           "tagStatus": "untagged",

--- a/ecr/ecr.tf
+++ b/ecr/ecr.tf
@@ -37,9 +37,9 @@ resource "aws_ecr_lifecycle_policy" "expiry_policy" {
   policy = jsonencode(
     {
       "rules" : flatten([
-        local.protected_tags,
+        local.protect_rules,
         {
-          "rulePriority" : length(var.protect_tags) + 1,
+          "rulePriority" : length(var.protected_tags) + 1,
           "description" : "Expire images older than ${var.valid_days} days",
           "selection" : {
             "tagStatus" : "any",

--- a/ecr/ecr.tf
+++ b/ecr/ecr.tf
@@ -15,14 +15,31 @@ resource "aws_ecr_repository" "main" {
   }
 }
 
+locals {
+  protect_rules = [for tag in var.protected_tags : {
+    "rulePriority" : index(var.protected_tags, tag) + 1,
+    "description" : "Protect ${tag}",
+    "selection" : {
+      "tagStatus" : "tagged",
+      "tagPrefixList" : [tag],
+      "countType" : "imageCountMoreThan",
+      "countNumber" : 1
+    },
+    "action" : {
+      "type" : "expire"
+    }
+  }]
+}
+
 resource "aws_ecr_lifecycle_policy" "expiry_policy" {
   repository = aws_ecr_repository.main.name
 
   policy = jsonencode(
     {
       "rules" : flatten([
+        local.protected_tags,
         {
-          "rulePriority" : var.valid_days,
+          "rulePriority" : length(var.protect_tags) + 1,
           "description" : "Expire images older than ${var.valid_days} days",
           "selection" : {
             "tagStatus" : "any",

--- a/ecr/variables.tf
+++ b/ecr/variables.tf
@@ -8,8 +8,9 @@ variable "valid_days" {
 }
 
 variable "protected_tags" {
-  type    = list(string)
-  default = []
+  type        = list(string)
+  default     = []
+  description = "Image with this tag will be kept at least one"
 }
 
 variable "ecr_lifecycle_policy_rules" {

--- a/ecr/variables.tf
+++ b/ecr/variables.tf
@@ -7,6 +7,11 @@ variable "valid_days" {
   default = 3
 }
 
+variable "protected_tags" {
+  type    = list(string)
+  default = []
+}
+
 variable "ecr_lifecycle_policy_rules" {
   type    = list(any)
   default = []


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary
Add ECR lifecycle policy rules to keep at least 1 images on important branch

#### Motivation
When running certain tasks (spin up a task on ECS), we require the image to exist on ECR