### PR TITLE
FIX: Elasticache output is a list

### DIFF
--- a/stack/app/outputs.tf
+++ b/stack/app/outputs.tf
@@ -7,7 +7,7 @@ output "database_arn" {
 }
 
 output "redis_url" {
-  value = var.skip_elasticache ? "" : module.elasticache[0].endpoint
+  value = var.skip_elasticache ? [] : module.elasticache[0].endpoint
 }
 
 output "vpc_id" {


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

fixes in stack / main / output


```
│ Error: Inconsistent conditional result types
│ 
│   on .terraform/modules/stack/stack/app/outputs.tf line 10, in output "redis_url":
│   10:   value = var.skip_elasticache ? "" : module.elasticache[0].endpoint
│     ├────────────────
│     │ module.elasticache[0].endpoint is list of string with 1 element
│     │ var.skip_elasticache is false
│ 
│ The true and false result expressions must have consistent types. The 'true' value is string, but the 'false' value is list of string.
```

which slipped through review here https://github.com/dbl-works/terraform/pull/174/

#### Motivation

<!-- Why are you making this change? -->
