### PR TITLE
Vpc peering public subnets

### DIFF
--- a/nat/nat.tf
+++ b/nat/nat.tf
@@ -48,6 +48,8 @@ resource "aws_route_table_association" "main" {
 
   lifecycle {
     # required to upgrade from a previous version
-    replace_triggered_by = aws_route_table.main[*].id
+    replace_triggered_by = [
+      aws_route_table.main[each.value].id,
+    ]
   }
 }

--- a/nat/nat.tf
+++ b/nat/nat.tf
@@ -28,7 +28,7 @@ resource "aws_route" "main" {
 
 # Create route tables so elastic IPs are used for outgoing traffic
 resource "aws_route_table" "main" {
-  count  = length(local.subnets_all)
+  count  = length(var.subnet_private_ids)
   vpc_id = var.vpc_id
 
   tags = {
@@ -41,7 +41,7 @@ resource "aws_route_table" "main" {
 # route tables for public subnet, e.g. if we want VPC peering between stacks without NATs
 # running the web process in a public subnet
 resource "aws_route_table_association" "main" {
-  for_each  = { for idx, subnet in local.subnets_all : subnet => idx }
+  for_each  = { for idx, subnet in var.subnet_private_ids : subnet => idx }
   subnet_id = each.key
 
   route_table_id = aws_route_table.main[each.value].id

--- a/nat/nat.tf
+++ b/nat/nat.tf
@@ -41,7 +41,7 @@ resource "aws_route_table" "main" {
 # route tables for public subnet, e.g. if we want VPC peering between stacks without NATs
 # running the web process in a public subnet
 resource "aws_route_table_association" "main" {
-  for_each  = { for idx, subnet in var.subnet_public_ids : subnet => idx }
+  for_each  = { for idx, subnet in var.subnet_private_ids : subnet => idx }
   subnet_id = each.key
 
   route_table_id = aws_route_table.main[each.value].id

--- a/nat/nat.tf
+++ b/nat/nat.tf
@@ -28,11 +28,11 @@ resource "aws_route" "main" {
 
 # Create route tables so elastic IPs are used for outgoing traffic
 resource "aws_route_table" "main" {
-  for_each = { for idx, subnet in local.subnets_all : subnet => idx }
-  vpc_id   = var.vpc_id
+  count  = length(var.subnet_public_ids)
+  vpc_id = var.vpc_id
 
   tags = {
-    Name        = "${var.project}-${var.environment}-nat-${each.value}"
+    Name        = "${var.project}-${var.environment}-nat-${count.index}"
     Environment = var.environment
     Project     = var.project
   }
@@ -41,7 +41,8 @@ resource "aws_route_table" "main" {
 # route tables for public subnet, e.g. if we want VPC peering between stacks without NATs
 # running the web process in a public subnet
 resource "aws_route_table_association" "main" {
-  for_each       = { for idx, subnet in local.subnets_all : subnet => idx }
-  subnet_id      = each.key
+  for_each  = { for idx, subnet in local.subnets_all : subnet => idx }
+  subnet_id = each.key
+
   route_table_id = aws_route_table.main[each.value].id
 }

--- a/nat/nat.tf
+++ b/nat/nat.tf
@@ -28,11 +28,11 @@ resource "aws_route" "main" {
 
 # Create route tables so elastic IPs are used for outgoing traffic
 resource "aws_route_table" "main" {
-  count  = length(local.subnets_all)
-  vpc_id = var.vpc_id
+  for_each = { for idx, subnet in local.subnets_all : subnet => idx }
+  vpc_id   = var.vpc_id
 
   tags = {
-    Name        = "${var.project}-${var.environment}-nat-${count.index}"
+    Name        = "${var.project}-${var.environment}-nat-${each.value}"
     Environment = var.environment
     Project     = var.project
   }
@@ -41,7 +41,7 @@ resource "aws_route_table" "main" {
 # route tables for public subnet, e.g. if we want VPC peering between stacks without NATs
 # running the web process in a public subnet
 resource "aws_route_table_association" "main" {
-  count          = length(local.subnets_all)
-  subnet_id      = local.subnets_all[count.index]
-  route_table_id = aws_route_table.main[count.index].id
+  for_each       = { for idx, subnet in local.subnets_all : subnet => idx }
+  subnet_id      = each.key
+  route_table_id = aws_route_table.main[each.value].id
 }

--- a/nat/nat.tf
+++ b/nat/nat.tf
@@ -28,7 +28,7 @@ resource "aws_route" "main" {
 
 # Create route tables so elastic IPs are used for outgoing traffic
 resource "aws_route_table" "main" {
-  count  = length(var.subnet_public_ids)
+  count  = length(local.subnets_all)
   vpc_id = var.vpc_id
 
   tags = {

--- a/nat/nat.tf
+++ b/nat/nat.tf
@@ -49,7 +49,7 @@ resource "aws_route_table_association" "main" {
   lifecycle {
     # required to upgrade from a previous version
     replace_triggered_by = [
-      aws_route_table.main[each.value].id,
+      aws_route_table.main[each.key].id,
     ]
   }
 }

--- a/nat/nat.tf
+++ b/nat/nat.tf
@@ -45,11 +45,4 @@ resource "aws_route_table_association" "main" {
   subnet_id = each.key
 
   route_table_id = aws_route_table.main[each.value].id
-
-  lifecycle {
-    # required to upgrade from a previous version
-    replace_triggered_by = [
-      aws_route_table.main[each.key].id,
-    ]
-  }
 }

--- a/nat/nat.tf
+++ b/nat/nat.tf
@@ -28,7 +28,7 @@ resource "aws_route" "main" {
 
 # Create route tables so elastic IPs are used for outgoing traffic
 resource "aws_route_table" "main" {
-  count  = length(var.subnet_private_ids)
+  count  = length(var.subnet_public_ids)
   vpc_id = var.vpc_id
 
   tags = {
@@ -41,7 +41,7 @@ resource "aws_route_table" "main" {
 # route tables for public subnet, e.g. if we want VPC peering between stacks without NATs
 # running the web process in a public subnet
 resource "aws_route_table_association" "main" {
-  for_each  = { for idx, subnet in var.subnet_private_ids : subnet => idx }
+  for_each  = { for idx, subnet in var.subnet_public_ids : subnet => idx }
   subnet_id = each.key
 
   route_table_id = aws_route_table.main[each.value].id

--- a/nat/nat.tf
+++ b/nat/nat.tf
@@ -38,8 +38,10 @@ resource "aws_route_table" "main" {
   }
 }
 
+# route tables for public subnet, e.g. if we want VPC peering between stacks without NATs
+# running the web process in a public subnet
 resource "aws_route_table_association" "main" {
-  count          = length(var.subnet_private_ids)
-  subnet_id      = var.subnet_private_ids[count.index]
+  count          = length(local.subnets_all)
+  subnet_id      = local.subnets_all[count.index]
   route_table_id = aws_route_table.main[count.index].id
 }

--- a/nat/nat.tf
+++ b/nat/nat.tf
@@ -45,4 +45,9 @@ resource "aws_route_table_association" "main" {
   subnet_id = each.key
 
   route_table_id = aws_route_table.main[each.value].id
+
+  lifecycle {
+    # required to upgrade from a previous version
+    replace_triggered_by = aws_route_table.main[*].id
+  }
 }

--- a/nat/variables.tf
+++ b/nat/variables.tf
@@ -4,11 +4,3 @@ variable "public_ips" {}
 variable "subnet_public_ids" {}
 variable "subnet_private_ids" {}
 variable "vpc_id" {}
-
-
-locals {
-  subnets_all = flatten(concat(
-    var.subnet_public_ids,
-    var.subnet_private_ids,
-  ))
-}

--- a/nat/variables.tf
+++ b/nat/variables.tf
@@ -4,3 +4,11 @@ variable "public_ips" {}
 variable "subnet_public_ids" {}
 variable "subnet_private_ids" {}
 variable "vpc_id" {}
+
+
+locals {
+  subnets_all = flatten(concat(
+    var.subnet_public_ids,
+    var.subnet_private_ids,
+  ))
+}

--- a/rds/parameter-group.tf
+++ b/rds/parameter-group.tf
@@ -30,6 +30,10 @@ resource "aws_db_parameter_group" "postgres13" {
     value        = -1 # this should be default, but apparently its not on AWS RDS https://postgresqlco.nf/doc/en/param/wal_buffers/
     apply_method = "pending-reboot"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_db_parameter_group" "postgres14" {
@@ -63,5 +67,9 @@ resource "aws_db_parameter_group" "postgres14" {
     name         = "wal_buffers"
     value        = -1
     apply_method = "pending-reboot"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -9,7 +9,7 @@ resource "aws_db_instance" "main" {
   engine                              = var.is_read_replica ? null : "postgres"
   engine_version                      = var.is_read_replica ? null : local.major_engine_version # Use major version only to allow AWS to update the minor/patch version automatically
   instance_class                      = var.instance_class
-  identifier                          = "${local.name}${var.is_read_replica ? "-read-replica" : ""}"
+  identifier                          = "${var.project}-${var.environment}${var.is_read_replica ? "-read-replica" : ""}"
   db_name                             = var.is_read_replica ? null : replace("${var.project}_${var.environment}", "/[^0-9A-Za-z_]/", "_") # name of the initial database
   skip_final_snapshot                 = true
   username                            = var.is_read_replica ? null : var.username # credentials of the master DB are used

--- a/rds/security-group.tf
+++ b/rds/security-group.tf
@@ -7,6 +7,10 @@ resource "aws_security_group" "db" {
     Project     = var.project
     Environment = var.environment
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "db-from-cidr-blocks" {

--- a/rds/subnet-group.tf
+++ b/rds/subnet-group.tf
@@ -1,14 +1,10 @@
 resource "aws_db_subnet_group" "main" {
-  name       = local.name
+  name       = var.subnet_group_name ? local.name : var.subnet_group_name
   subnet_ids = var.subnet_ids
 
   tags = {
-    Name        = local.name
+    Name        = var.subnet_group_name ? local.name : var.subnet_group_name
     Project     = var.project
     Environment = var.environment
-  }
-
-  lifecycle {
-    create_before_destroy = true
   }
 }

--- a/rds/subnet-group.tf
+++ b/rds/subnet-group.tf
@@ -1,9 +1,9 @@
 resource "aws_db_subnet_group" "main" {
-  name       = var.subnet_group_name ? local.name : var.subnet_group_name
+  name       = var.subnet_group_name == null ? local.name : var.subnet_group_name
   subnet_ids = var.subnet_ids
 
   tags = {
-    Name        = var.subnet_group_name ? local.name : var.subnet_group_name
+    Name        = var.subnet_group_name == null ? local.name : var.subnet_group_name
     Project     = var.project
     Environment = var.environment
   }

--- a/rds/subnet-group.tf
+++ b/rds/subnet-group.tf
@@ -7,4 +7,8 @@ resource "aws_db_subnet_group" "main" {
     Project     = var.project
     Environment = var.environment
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -79,6 +79,10 @@ variable "enable_replication" {
   default     = false
 }
 
+variable "subnet_group_name" {
+  type = string
+}
+
 locals {
   name             = var.name != null ? var.name : "${var.project}-${var.environment}${var.regional ? "-${var.region}" : ""}"
   name_underscored = var.name != null ? replace(var.name, "-", "_") : "${var.project}_${var.environment}${var.regional ? "_${var.region}" : ""}"

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -80,7 +80,8 @@ variable "enable_replication" {
 }
 
 variable "subnet_group_name" {
-  type = string
+  type    = string
+  default = null
 }
 
 locals {

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -114,7 +114,7 @@ module "stack" {
   rds_name                          = null # unique name, shouldn't be necessary if "regional" is set to true
   rds_multi_region_kms_key          = false # set to true for the MASTER stack, so that replicas can create a replica of the key
   rds_allow_from_cidr_blocks        = [] # non-master regions must be granted access to RDS by passing their CIDR block ( vpc-peering enabled! )
-  rds_master_nat_route_table_ids    = [] # for the peering connection
+  rds_master_nat_route_table_ids    = [] # for the peering connection, pass route tables for public and private subnets
 
   # ECS
   allow_internal_traffic_to_ports = []

--- a/stack/app/rds.tf
+++ b/stack/app/rds.tf
@@ -44,4 +44,5 @@ module "rds" {
   regional               = var.regional
   name                   = var.rds_name
   allow_from_cidr_blocks = var.rds_allow_from_cidr_blocks
+  subnet_group_name      = var.rds_subnet_group_name
 }

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -248,7 +248,7 @@ variable "rds_allow_from_cidr_blocks" {
 }
 
 variable "rds_subnet_group_name" {
-  type = string
+  type    = string
   default = null
 }
 # =============== RDS ================ #

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -246,6 +246,11 @@ variable "rds_allow_from_cidr_blocks" {
   type    = list(string)
   default = []
 }
+
+variable "rds_subnet_group_name" {
+  type = string
+  default = null
+}
 # =============== RDS ================ #
 
 # =============== ECS ================ #

--- a/stack/app/vpc-peering.tf
+++ b/stack/app/vpc-peering.tf
@@ -10,10 +10,14 @@ module "vpc-peering" {
   project     = var.project
   environment = var.environment
 
-  requester_region              = var.region
-  requester_vpc_id              = module.vpc.id
-  requester_cidr_block          = var.vpc_cidr_block
-  requester_nat_route_table_ids = module.nat.aws_route_table_ids
+  requester_region     = var.region
+  requester_vpc_id     = module.vpc.id
+  requester_cidr_block = var.vpc_cidr_block
+  requester_nat_route_table_ids = flatten(concat(
+    module.nat.aws_route_table_ids,
+    module.vpc.route_table_ids,
+
+  ))
 
   accepter_region              = var.rds_master_db_region
   accepter_vpc_id              = var.rds_master_db_vpc_id

--- a/stack/app/vpc-peering.tf
+++ b/stack/app/vpc-peering.tf
@@ -1,10 +1,6 @@
-locals {
-  enable_vpc_peering = var.vpc_peering || var.rds_is_read_replica
-}
-
 module "vpc-peering" {
   source = "../../vpc-peering"
-  count  = local.enable_vpc_peering ? 1 : 0
+  count  = var.vpc_peering ? 1 : 0
 
   providers = {
     aws      = aws

--- a/vpc/outputs.tf
+++ b/vpc/outputs.tf
@@ -14,3 +14,7 @@ output "subnet_public_ids" {
 output "subnet_private_ids" {
   value = aws_subnet.private.*.id
 }
+
+output "route_table_ids" {
+  value = aws_route_table.main[*].id
+}


### PR DESCRIPTION
#### Summary

Fix VPC peering when deploying the application task in ECS to a public subnet instead of a private subnet.

This requires adding a route for the peering-connection to the route-table associated with the public subnets (so far this route was only added to the tables associated with the private subnets).



#### Motivation

We want to save costs for some stacks and not have a NAT. One solution is to move the application tasks to a public subnet (and secure them via policies).
