### PR TITLE
[Hotfix] Fix S3 bucket access in ecs module

### DIFF
--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -37,12 +37,12 @@ module "ecs" {
   ])))
 
   grant_read_access_to_s3_arns = distinct(flatten(concat([
-    [for arn in values(module.s3-storage)[*].arn : "${arn}/*"],
+    [for arn in values(module.s3-storage)[*].arn : arn],
     var.grant_read_access_to_s3_arns
   ])))
 
   grant_write_access_to_s3_arns = distinct(flatten(concat([
-    [for arn in values(module.s3-storage)[*].arn : "${arn}/*"],
+    [for arn in values(module.s3-storage)[*].arn : arn],
     var.grant_write_access_to_s3_arns
   ])))
 


### PR DESCRIPTION
#### Summary
In ecs/execution-role.tf, tf only loop the variables and make sure the bucket/* is accessible. We should not pass the variables in the `bucket/*` format => it will result in `bucket/*/*` in the policy
