### PR TITLE
Consider ECS Clusters with regional name

### DIFF
--- a/ecs_service/ecs_service.tf
+++ b/ecs_service/ecs_service.tf
@@ -1,5 +1,10 @@
+locals {
+  name = var.cluster_name != null ? var.cluster_name : "${var.project}-${var.environment}${var.regional ? "-${var.region}" : ""}"
+}
+
+
 data "aws_ecs_cluster" "main" {
-  cluster_name = "${var.project}-${var.environment}"
+  cluster_name = local.name
 }
 
 data "aws_iam_role" "main" {

--- a/ecs_service/ecs_service.tf
+++ b/ecs_service/ecs_service.tf
@@ -8,11 +8,11 @@ data "aws_ecs_cluster" "main" {
 }
 
 data "aws_iam_role" "main" {
-  name = "ecs-task-execution-${var.project}-${var.environment}"
+  name = "ecs-task-execution-${local.name}"
 }
 
 data "aws_lb_target_group" "ecs" {
-  name = "${var.project}-${var.environment}-ecs"
+  name = "${local.name}-ecs"
 }
 
 data "aws_vpc" "main" {
@@ -36,7 +36,7 @@ data "aws_subnets" "public" {
 }
 
 data "aws_security_group" "ecs" {
-  name = "${var.project}-${var.environment}-ecs"
+  name = "${local.name}-ecs"
 }
 
 resource "aws_ecs_service" "main" {

--- a/ecs_service/variables.tf
+++ b/ecs_service/variables.tf
@@ -1,3 +1,14 @@
+variable "regional" {
+  type    = bool
+  default = false
+}
+
+variable "region" {
+  type        = string
+  default     = null
+  description = "Typically, we abbreviate the region for naming, e.g. 'us-east-1' is passed as 'us-east'."
+}
+
 variable "project" {
   type = string
 }

--- a/ecs_service/variables.tf
+++ b/ecs_service/variables.tf
@@ -13,6 +13,12 @@ variable "project" {
   type = string
 }
 
+variable "cluster_name" {
+  type        = string
+  default     = null
+  description = "If not provided, the cluster name will be generated from the project and environment (and region if regional)."
+}
+
 variable "environment" {
   type = string
 }


### PR DESCRIPTION
- WIP: allow passing regional names for ecs clusters
- fix: add cluster_name var
- iam role, target groups, security groups are regional

<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

<!-- What does the code do? What have you changed? Consider adding before/after screenshots or command line logs. What is the current behavior? What is the expected behavior? -->

#### Motivation

<!-- Why are you making this change? -->
