### PR TITLE
Allow logger side-cear container to access secrets

### DIFF
--- a/ecs_service/README.md
+++ b/ecs_service/README.md
@@ -24,6 +24,7 @@ module "ecs_service" {
   logger_image_tag       = "latest-main"
   memory                 = 512
   secrets                = []
+  logger_secrets         = [] # e.g. tokens for remote services logs are sent to
   secrets_alias          = null # defaults to "${var.project}/app/${var.environment}"
   service_json_file_name = "web_with_logger" # or: "web" for no logging, or "sidekiq_with_logger" for sidekiq
   with_load_balancer     = false

--- a/ecs_service/locals.tf
+++ b/ecs_service/locals.tf
@@ -64,6 +64,7 @@ locals {
     LOG_PATH              = var.log_path
     LOGGER_CONTAINER_PORT = var.logger_container_port
     LOGGER_IMAGE_NAME     = local.logger_image_name
+    SECRETS_LIST          = jsonencode(local.logger_secrets)
     PROJECT               = var.project
     REGION                = local.region
     VOLUME_NAME           = var.volume_name

--- a/ecs_service/locals.tf
+++ b/ecs_service/locals.tf
@@ -15,6 +15,12 @@ locals {
       valueFrom : "${data.aws_secretsmanager_secret.app.arn}:${secret_name}::"
     }
   ]
+  logger_secrets = [
+    for secret_name in var.logger_secrets : {
+      name : secret_name,
+      valueFrom : "${data.aws_secretsmanager_secret.app.arn}:${secret_name}::"
+    }
+  ]
 
   app_port_mappings = var.app_container_port == null ? [] : [{
     containerPort : var.app_container_port,

--- a/ecs_service/task-definitions/logger.json
+++ b/ecs_service/task-definitions/logger.json
@@ -17,6 +17,7 @@
       }
   ],
   "volumesFrom": [],
+  "secrets": ${SECRETS_LIST},
   "readonlyRootFilesystem": false,
   "logConfiguration": {
       "logDriver": "awslogs",

--- a/ecs_service/variables.tf
+++ b/ecs_service/variables.tf
@@ -112,7 +112,13 @@ variable "environment_variables" {
 variable "secrets" {
   type        = list(string)
   default     = []
-  description = "secrets key which is stored in the aws secret"
+  description = "keys of secrets stored in the aws secrets manager required for the app"
+}
+
+variable "logger_secrets" {
+  type        = list(string)
+  default     = []
+  description = "keys of secrets stored in the aws secrets manager required for the logger"
 }
 
 variable "commands" {


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

Allow granting access to secrets to the logger container

#### Motivation

I want to move API keys for external log sinks out of the vector config file (git tracked) to AWS Secrets Manager.

Example from a vector config file:

```toml
  [sinks.logtail_http_sink.auth]
    strategy = "bearer"
    token    = "${LOGTAIL_VECTOR_SINK_TOKEN}"
```

For this to work, we need to grant the logger container access to some (but not all) secrets.

We should use a different `secrets` variable for this, since the logger should not have access to all secrets; it is not necessary and can only lead to bugs where we inject sensitive data into the logs by accident.
