### PR TITLE
[Chore] Update MFA policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project does not follow SemVer, since modules are independent of each other
 ### iam/iam-policy-for-cross-account-access
 - Add IAM policy for cross account access [#195](https://github.com/dbl-works/terraform/pull/195)
 
+### iam/iam-for-humans/human-policies
+- Allow user to create MFA device under any name [#204](https://github.com/dbl-works/terraform/pull/204)
+
 ## [v2023.03.30]
 ### global-accelerator
 - Add `weight` to the load_balancers variables, defaulting to 128 [#194](https://github.com/dbl-works/terraform/pull/194)

--- a/iam/iam-for-humans/human-policies.tf
+++ b/iam/iam-for-humans/human-policies.tf
@@ -10,66 +10,65 @@ resource "aws_iam_policy" "iam-humans-usage" {
   path        = "/"
   description = "Allow humans to manage their own credentials"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AllowViewAccountInfo",
-      "Effect": "Allow",
-      "Action": [
-        "iam:GetAccountPasswordPolicy",
-        "iam:GetAccountSummary",
-        "iam:ListVirtualMFADevices"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Sid": "AllowManageOwnPasswords",
-      "Effect": "Allow",
-      "Action": [
-        "iam:ChangePassword",
-        "iam:GetUser"
-      ],
-      "Resource": "arn:aws:iam::*:user/$${aws:username}"
-    },
-    {
-      "Sid": "AllowManageOwnAccessKeys",
-      "Effect": "Allow",
-      "Action": [
-        "iam:CreateAccessKey",
-        "iam:DeleteAccessKey",
-        "iam:GetAccessKeyLastUsed",
-        "iam:ListAccessKeys",
-        "iam:UpdateAccessKey"
-      ],
-      "Resource": "arn:aws:iam::*:user/$${aws:username}"
-    },
-    {
-      "Sid": "AllowManageOwnVirtualMFADevice",
-      "Effect": "Allow",
-      "Action": [
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowViewAccountInfo",
+        Effect = "Allow",
+        Action = [
+          "iam:GetAccountPasswordPolicy",
+          "iam:GetAccountSummary",
+          "iam:ListVirtualMFADevices"
+        ],
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowManageOwnPasswords",
+        Effect = "Allow",
+        Action = [
+          "iam:ChangePassword",
+          "iam:GetUser"
+        ],
+        Resource = "arn:aws:iam::*:user/$${aws:username}"
+      },
+      {
+        Sid    = "AllowManageOwnAccessKeys",
+        Effect = "Allow",
+        Action = [
+          "iam:CreateAccessKey",
+          "iam:DeleteAccessKey",
+          "iam:GetAccessKeyLastUsed",
+          "iam:ListAccessKeys",
+          "iam:UpdateAccessKey"
+        ],
+        Resource = "arn:aws:iam::*:user/$${aws:username}"
+      },
+      {
+        Sid    = "AllowManageVirtualMFADevice",
+        Effect = "Allow",
+        Action = [
           "iam:CreateVirtualMFADevice",
           "iam:DeleteVirtualMFADevice"
-      ],
-      "Resource": "arn:aws:iam::*:mfa/$${aws:username}"
-    },
-    {
-      "Sid": "AllowManageOwnUserMFA",
-      "Effect": "Allow",
-      "Action": [
-        "iam:DeactivateMFADevice",
-        "iam:EnableMFADevice",
-        "iam:GetUser",
-        "iam:ListMFADevices",
-        "iam:ResyncMFADevice"
-      ],
-      "Resource": "arn:aws:iam::*:user/$${aws:username}"
-    }
-  ]
+        ],
+        "Resource" : "arn:aws:iam::*:mfa/*"
+      },
+      {
+        Sid    = "AllowManageOwnUserMFA",
+        Effect = "Allow",
+        Action = [
+          "iam:DeactivateMFADevice",
+          "iam:EnableMFADevice",
+          "iam:GetUser",
+          "iam:ListMFADevices",
+          "iam:ResyncMFADevice"
+        ],
+        Resource = "arn:aws:iam::*:user/$${aws:username}"
+      }
+    ]
+  })
 }
-EOF
-}
+
 resource "aws_iam_group_policy_attachment" "iam-humans-usage" {
   group      = "humans"
   policy_arn = aws_iam_policy.iam-humans-usage.arn

--- a/iam/iam-for-humans/human-policies.tf
+++ b/iam/iam-for-humans/human-policies.tf
@@ -45,13 +45,25 @@ resource "aws_iam_policy" "iam-humans-usage" {
         Resource = "arn:aws:iam::*:user/$${aws:username}"
       },
       {
-        Sid    = "AllowManageVirtualMFADevice",
+        Sid    = "AllowCreateVirtualMFADevice",
         Effect = "Allow",
         Action = [
           "iam:CreateVirtualMFADevice",
-          "iam:DeleteVirtualMFADevice"
         ],
         "Resource" : "arn:aws:iam::*:mfa/*"
+      },
+      {
+        Sid    = "AllowDeleteVirtualMFADevice",
+        Effect = "Allow",
+        Action = [
+          "iam:DeleteVirtualMFADevice"
+        ],
+        Resource = "arn:aws:iam::*:mfa/*",
+        Condition = {
+          "Bool" : {
+            "aws:MultiFactorAuthPresent" : "true"
+          }
+        }
       },
       {
         Sid    = "AllowManageOwnUserMFA",
@@ -64,6 +76,23 @@ resource "aws_iam_policy" "iam-humans-usage" {
           "iam:ResyncMFADevice"
         ],
         Resource = "arn:aws:iam::*:user/$${aws:username}"
+      },
+      {
+        Sid    = "DenyAllExceptListedIfNoMFA",
+        Effect = "Deny",
+        NotAction = [
+          "iam:CreateVirtualMFADevice",
+          "iam:EnableMFADevice",
+          "iam:GetUser",
+          "iam:ListMFADevices",
+          "iam:ListVirtualMFADevices",
+          "iam:ResyncMFADevice",
+          "sts:GetSessionToken"
+        ],
+        Resource = "*",
+        Condition = {
+          "BoolIfExists" : { "aws:MultiFactorAuthPresent" : "false" }
+        }
       }
     ]
   })

--- a/iam/iam-for-humans/human-policies.tf
+++ b/iam/iam-for-humans/human-policies.tf
@@ -76,23 +76,6 @@ resource "aws_iam_policy" "iam-humans-usage" {
           "iam:ResyncMFADevice"
         ],
         Resource = "arn:aws:iam::*:user/$${aws:username}"
-      },
-      {
-        Sid    = "DenyAllExceptListedIfNoMFA",
-        Effect = "Deny",
-        NotAction = [
-          "iam:CreateVirtualMFADevice",
-          "iam:EnableMFADevice",
-          "iam:GetUser",
-          "iam:ListMFADevices",
-          "iam:ListVirtualMFADevices",
-          "iam:ResyncMFADevice",
-          "sts:GetSessionToken"
-        ],
-        Resource = "*",
-        Condition = {
-          "BoolIfExists" : { "aws:MultiFactorAuthPresent" : "false" }
-        }
       }
     ]
   })


### PR DESCRIPTION
#### Summary
In the latest AWS, user is allowed to name the MFA service.
Therefore the mfa service is no longer a static value (eg. aws:username)
The current setup only allow user to name the MFA service using the aws username

```
    {
      "Sid": "AllowManageOwnVirtualMFADevice",
      "Effect": "Allow",
      "Action": [
          "iam:CreateVirtualMFADevice",
          "iam:DeleteVirtualMFADevice"
      ],
      "Resource": "arn:aws:iam::*:mfa/$${aws:username}"
    }
```
This update
- allow the user to create MFA under any name
- ~deny users from performing most of the actions unless they setup their MFA~ (Remove this because it prohibits a lot of cli actions)

![Screenshot 2023-04-28 at 3 15 00 PM](https://user-images.githubusercontent.com/15337955/235088341-39953c4d-36a5-45b7-a04e-c7dfa3989d2a.png)
~_eg. User would see only the loading spinner when trying to access the ECS cluster_~

#### Motivation
https://github.com/dbl-works/terraform/issues/163
