### PR TITLE
Fix period override in CloudWatch

### DIFF
--- a/cloudwatch/main.tf
+++ b/cloudwatch/main.tf
@@ -26,7 +26,8 @@ locals {
           "view" : "singleValue",
           "sparkline" : true,
           "stat" : "Sum",
-          "period" : 60,
+          "period" : 1,
+          "unit" : "Minutes",
           "metrics" : [
             ["AWS/ApplicationELB", "RequestCount", "LoadBalancer", name, { "label" : name }]
           ],

--- a/cloudwatch/main.tf
+++ b/cloudwatch/main.tf
@@ -26,8 +26,8 @@ locals {
           "view" : "singleValue",
           "sparkline" : true,
           "stat" : "Sum",
-          "period" : 1,
-          "unit" : "Minutes",
+          "period" : 60,
+          "unit" : "Seconds",
           "metrics" : [
             ["AWS/ApplicationELB", "RequestCount", "LoadBalancer", name, { "label" : name }]
           ],

--- a/cloudwatch/main.tf
+++ b/cloudwatch/main.tf
@@ -459,6 +459,7 @@ resource "aws_cloudwatch_dashboard" "main" {
   dashboard_name = local.name
 
   dashboard_body = jsonencode({
+    "periodOverride" : "inherit", # defaults to auto, which means periods auto-adjust depending on the time range of the dashboard
     "widgets" : flatten(concat(
       local.alb_performance_metrics,
       local.elasticache_performance_metrics,


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

<img width="380" alt="image" src="https://github.com/dbl-works/terraform/assets/20702503/09848ff4-d865-4c65-b2af-ff85449324e2">


#### Motivation

the stats label is "... per min", but if the time range of the dashboard is changed to e.g. 1 week, cloudwatch by default auto-adjusts the period (e.g. to 1 hour), but the label still prints " ... per min", which is very confusing.

This PR fixes this by forcing the dashboard to always respect the configured period regardless of the time range chosen.