### PR TITLE
Ensure the correct parameter group is used, regardless of engine version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 This project does not follow SemVer, since modules are independent of each other; thus, SemVer does not make sense. Changes are grouped per module.
 
 ## [Unreleased]
+### RDS
+- new optional variable for `parameter_group_name`, #213
+- parameter group is now created dynamically depending on the engine version (instead of hardcoding version 13 and 14), #213
+- allow major version upgrades, #213
+- ignore changes to username/password to not trigger a re-creation when the password is rotated, #213
+
 ### aws-transfer
 - Add AWS transfer family module[#198](https://github.com/dbl-works/terraform/pull/198)
 

--- a/rds/README.md
+++ b/rds/README.md
@@ -34,6 +34,7 @@ module "db" {
   name                   = null # defaults to "${var.project}-${var.environment}", may need to be unique per region
   snapshot_identifier    = "" # crate from snapshot
   allow_from_cidr_blocks = []
+  parameter_group_name   = null # the module will create a custom parameter group if this is not set
 
   # when creating a read-replica
   master_db_instance_arn = null  # ARN of the master database

--- a/rds/parameter-group.tf
+++ b/rds/parameter-group.tf
@@ -1,44 +1,9 @@
-resource "aws_db_parameter_group" "postgres13" {
-  name   = "${local.name}-postgres13"
-  family = "postgres13"
-  parameter {
-    name  = "log_statement"
-    value = "all"
-  }
-  parameter {
-    name  = "log_min_duration_statement"
-    value = "0"
-  }
-  parameter {
-    name  = "rds.force_ssl"
-    value = 1
-  }
+resource "aws_db_parameter_group" "current" {
+  count = var.parameter_group_name == null ? 1 : 0
 
-  parameter {
-    name         = "rds.logical_replication"
-    value        = var.enable_replication ? 1 : 0
-    apply_method = "pending-reboot"
-  }
-  parameter {
-    name         = "wal_sender_timeout"
-    value        = var.enable_replication ? 0 : 60000 # default, 1 min
-    apply_method = "pending-reboot"
-  }
+  name   = "${local.name}-postgres${local.major_engine_version}"
+  family = "postgres${local.major_engine_version}"
 
-  parameter {
-    name         = "wal_buffers"
-    value        = -1 # this should be default, but apparently its not on AWS RDS https://postgresqlco.nf/doc/en/param/wal_buffers/
-    apply_method = "pending-reboot"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_db_parameter_group" "postgres14" {
-  name   = "${local.name}-postgres14"
-  family = "postgres14"
   parameter {
     name  = "log_statement"
     value = "all"

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -59,6 +59,8 @@ resource "aws_db_instance" "main" {
       engine_version, # AWS will auto-update minor version changes
       db_name,        # if you didn't use this before it would re-create your RDS instance
       snapshot_identifier,
+      username,
+      password,
     ]
   }
 }

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -18,7 +18,7 @@ resource "aws_db_instance" "main" {
   username                            = var.is_read_replica ? null : var.username                                                         # credentials of the master DB are used
   password                            = var.is_read_replica ? null : var.password                                                         # credentials of the master DB are used
   iam_database_authentication_enabled = true
-  parameter_group_name                = local.parameter_group_name # 13, 14, or default for the choosen engine version
+  parameter_group_name                = var.parameter_group_name != null ? var.parameter_group_name : local.parameter_group_name # 13, 14, or default for the choosen engine version
   apply_immediately                   = true
   multi_az                            = var.multi_az
   publicly_accessible                 = var.publicly_accessible

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -1,7 +1,8 @@
 locals {
   major_engine_version      = split(".", var.engine_version)[0]
   final_snapshot_identifier = "final-snapshot-${var.project}-${var.environment}-${formatdate("DD-MM-YY-hhmm", timestamp())}"
-  parameter_group_name      = local.major_engine_version == "14" ? aws_db_parameter_group.postgres14.name : local.major_engine_version == "13" ? aws_db_parameter_group.postgres13.name : "default.postgres${local.major_engine_version}"
+  # @NOTE: `"default.postgres${local.major_engine_version}"` does not exist for e.g. postgres15 eventhough, postges 15 is generally available
+  parameter_group_name = local.major_engine_version == "14" ? aws_db_parameter_group.postgres14.name : local.major_engine_version == "13" ? aws_db_parameter_group.postgres13.name : null
 }
 
 resource "aws_db_instance" "main" {

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -6,6 +6,7 @@ locals {
 }
 
 resource "aws_db_instance" "main" {
+  allow_major_version_upgrade         = true
   db_subnet_group_name                = aws_db_subnet_group.main.name
   allocated_storage                   = var.allocated_storage
   storage_type                        = "gp2"

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -1,8 +1,7 @@
 locals {
   major_engine_version      = split(".", var.engine_version)[0]
   final_snapshot_identifier = "final-snapshot-${var.project}-${var.environment}-${formatdate("DD-MM-YY-hhmm", timestamp())}"
-  # @NOTE: `"default.postgres${local.major_engine_version}"` does not exist for e.g. postgres15 eventhough, postges 15 is generally available
-  parameter_group_name = local.major_engine_version == "14" ? aws_db_parameter_group.postgres14.name : local.major_engine_version == "13" ? aws_db_parameter_group.postgres13.name : null
+  parameter_group_name      = var.parameter_group_name == null ? aws_db_parameter_group.current[0].name : var.parameter_group_name
 }
 
 resource "aws_db_instance" "main" {
@@ -18,7 +17,7 @@ resource "aws_db_instance" "main" {
   username                            = var.is_read_replica ? null : var.username                                                         # credentials of the master DB are used
   password                            = var.is_read_replica ? null : var.password                                                         # credentials of the master DB are used
   iam_database_authentication_enabled = true
-  parameter_group_name                = var.parameter_group_name != null ? var.parameter_group_name : local.parameter_group_name # 13, 14, or default for the choosen engine version
+  parameter_group_name                = local.parameter_group_name
   apply_immediately                   = true
   multi_az                            = var.multi_az
   publicly_accessible                 = var.publicly_accessible

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -1,6 +1,7 @@
 locals {
   major_engine_version      = split(".", var.engine_version)[0]
   final_snapshot_identifier = "final-snapshot-${var.project}-${var.environment}-${formatdate("DD-MM-YY-hhmm", timestamp())}"
+  parameter_group_name      = local.major_engine_version == "14" ? aws_db_parameter_group.postgres14.name : local.major_engine_version == "13" ? aws_db_parameter_group.postgres13.name : "default.postgres${local.major_engine_version}"
 }
 
 resource "aws_db_instance" "main" {
@@ -15,7 +16,7 @@ resource "aws_db_instance" "main" {
   username                            = var.is_read_replica ? null : var.username                                                         # credentials of the master DB are used
   password                            = var.is_read_replica ? null : var.password                                                         # credentials of the master DB are used
   iam_database_authentication_enabled = true
-  parameter_group_name                = local.major_engine_version == "14" ? aws_db_parameter_group.postgres14.name : aws_db_parameter_group.postgres13.name
+  parameter_group_name                = local.parameter_group_name # 13, 14, or default for the choosen engine version
   apply_immediately                   = true
   multi_az                            = var.multi_az
   publicly_accessible                 = var.publicly_accessible

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -18,6 +18,11 @@ variable "publicly_accessible" {
   default = false
 }
 
+variable "parameter_group_name" {
+  type    = string
+  default = null
+}
+
 variable "multi_az" {
   type    = bool
   default = false


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

Previously, if the engine version was not 14, version 13 was assumed for the parameter group.

This obviously does not allow creating new instances using any other version.

#### Motivation


Postgres 15 was released on AWS.
