### PR TITLE
ecs: add alb listener rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This project does not follow SemVer, since modules are independent of each other
 ## Unreleased
 ### ecs-deploy
 - Set app and sidecar default container port to null
+- Add aws_lb_target_group_arn to allow user to configure the load_balancer block [#216](https://github.com/dbl-works/terraform/pull/216)
+
+### ecs
+- add alb_listener_rule and allow_alb_traffic_to_ports options [#216](https://github.com/dbl-works/terraform/pull/216)
+
+### stack/app
+- add alb_listener_rule and allow_alb_traffic_to_ports options [#216](https://github.com/dbl-works/terraform/pull/216)
 
 ## [v2023.05.15]
 ### RDS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project does not follow SemVer, since modules are independent of each other
 - Add aws_lb_target_group_arn to allow user to configure the load_balancer block [#216](https://github.com/dbl-works/terraform/pull/216)
 
 ### ecs
-- add alb_listener_rule and allow_alb_traffic_to_ports options [#216](https://github.com/dbl-works/terraform/pull/216)
+- add alb_listener_rule and allow_alb_traffic_to_ports options, remove subnet_private_ids since it is not used [#216](https://github.com/dbl-works/terraform/pull/216)
 
 ### stack/app
 - add alb_listener_rule and allow_alb_traffic_to_ports options [#216](https://github.com/dbl-works/terraform/pull/216)

--- a/ecs-deploy/README.md
+++ b/ecs-deploy/README.md
@@ -36,5 +36,7 @@ module "ecs-deploy" {
   volume_name            = "log"
   with_logger            = false
   desired_count          = 2
+
+  aws_lb_target_group_arn = "arn::"
 }
 ```

--- a/ecs-deploy/README.md
+++ b/ecs-deploy/README.md
@@ -11,32 +11,32 @@ module "ecs-deploy" {
   project              = local.project
   environment          = local.environment
   ecr_repo_name        = "facebook"
-  logger_ecr_repo_name = "facebook-log"
 
   # Optional
-  app_container_port     = 3000 # set to "null" to skip port mapping, necessary e.g. for sidekiq
-  app_image_name         = "google/cloud-sdk"
-  commands               = ["bundle", "exec", "puma", "-C", "config/puma.rb"]
-  container_name         = "web"
-  cpu                    = 256
-  environment_variables  = {}
-  app_image_tag          = "latest-main"
-  logger_image_tag       = "latest-main"
-  memory                 = 512
-  secrets                = []
-  logger_secrets         = [] # e.g. tokens for remote services logs are sent to
-  secrets_alias          = null # defaults to "${var.project}/app/${var.environment}"
-  service_json_file_name = "web_with_logger" # or: "web" for no logging, or "sidekiq_with_logger" for sidekiq
-  with_load_balancer     = false
+  cpu                     = 256
+  memory                  = 512
+  desired_count           = 2
+  with_load_balancer      = true
+  app_config = {
+    name                  = "facebook"
+    image_tag             = "v1.0"
+    ecr_repo_name         = "facebook"
+    commands              = ["node", "index.js"]
+    container_port        = 5000
+    environment_variables = {}
+    secrets               = []
+  }
 
-  log_path               = "log"
-  logger_container_port  = 4318
-  logger_ecr_repo_name   = "logger-private-registry"
-  logger_image_name      = "google/logger"
-  volume_name            = "log"
-  with_logger            = false
-  desired_count          = 2
+  sidecar_config = [{
+    name           = "statsd"
+    image_tag      = "v0.10.1"
+    image_name     = "statsd/statsd"
+    secrets        = []
+    container_port = 8125
+    protocol       = "udp"
+    mount_points   = []
+  }]
 
-  aws_lb_target_group_arn = "arn::"
+  aws_lb_target_group_arn = "arn:aws:elasticloadbalancing:eu-central-1:account-id:targetgroup/facebook/xxxxxxxxxxxxxxxx"
 }
 ```

--- a/ecs-deploy/ecs_service.tf
+++ b/ecs-deploy/ecs_service.tf
@@ -52,11 +52,11 @@ resource "aws_ecs_service" "main" {
 
   locals {
     # There are 3 possibilities here:
-    # 1. Load balancer is needed but no load balancer configuration is passed in => Use the default ecs load balancer
-    # 2. Load balancer is needed and load balancer configuration is passed in => Use the load balancer configuration
+    # 1. Load balancer is needed but no target group arn is passed in => Use the default ecs target group
+    # 2. Load balancer is needed and target group arn is passed in => Use the aws_lb_target_group_arn
     # 3. Load balancer is not needed => Don't configure load balancer
-    load_balancers = var.with_load_balancer ? length(var.load_balancers) > 0 ? var.load_balancers : [{
-      target_group_arn = data.aws_lb_target_group.ecs.arn,
+    load_balancers = var.with_load_balancer ? [{
+      target_group_arn = var.aws_lb_target_group_arn == null ? data.aws_lb_target_group.ecs.arn : aws_lb_target_group_arn
       container_name   = var.app_config.name,
       container_port   = var.app_config.container_port
     }] : []

--- a/ecs-deploy/ecs_service.tf
+++ b/ecs-deploy/ecs_service.tf
@@ -56,7 +56,7 @@ resource "aws_ecs_service" "main" {
     # 2. Load balancer is needed and target group arn is passed in => Use the aws_lb_target_group_arn
     # 3. Load balancer is not needed => Don't configure load balancer
     load_balancers = var.with_load_balancer ? [{
-      target_group_arn = var.aws_lb_target_group_arn == null ? data.aws_lb_target_group.ecs.arn : aws_lb_target_group_arn
+      target_group_arn = var.aws_lb_target_group_arn == null ? data.aws_lb_target_group.ecs.arn : var.aws_lb_target_group_arn
       container_name   = var.app_config.name,
       container_port   = var.app_config.container_port
     }] : []

--- a/ecs-deploy/variables.tf
+++ b/ecs-deploy/variables.tf
@@ -117,3 +117,11 @@ variable "cloudwatch_logs_retention_in_days" {
   type    = number
   default = 7
 }
+
+variable "load_balancers" {
+  type = list(object({
+    target_group_arn = string
+    container_name   = string
+    container_port   = number
+  }))
+}

--- a/ecs-deploy/variables.tf
+++ b/ecs-deploy/variables.tf
@@ -118,10 +118,7 @@ variable "cloudwatch_logs_retention_in_days" {
   default = 7
 }
 
-variable "load_balancers" {
-  type = list(object({
-    target_group_arn = string
-    container_name   = string
-    container_port   = number
-  }))
+variable "aws_lb_target_group_arn" {
+  type    = string
+  default = null
 }

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -52,7 +52,7 @@ module "ecs" {
 
   allow_internal_traffic_to_ports = []
   allow_alb_traffic_to_ports = [5000]
-  alb_listener_rule = [
+  alb_listener_rules = [
     {
       priority         = 1
       type             = "forward"

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -13,7 +13,6 @@ module "ecs" {
   project            = local.project
   environment        = local.environment
   vpc_id             = module.vpc.id
-  subnet_private_ids = module.vpc.subnet_private_ids
   subnet_public_ids  = module.vpc.subnet_private_ids
 
   # optional

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -35,7 +35,7 @@ module "ecs" {
   project            = local.project
   environment        = local.environment
   vpc_id             = module.vpc.id
-  subnet_public_ids  = module.vpc.subnet_private_ids
+  subnet_public_ids  = module.vpc.subnet_public_ids
 
   # optional
   secrets_arns                = []

--- a/ecs/alb.tf
+++ b/ecs/alb.tf
@@ -69,14 +69,4 @@ resource "aws_lb_listener_rule" "main" {
       }
     }
   }
-
-  dynamic "condition" {
-    for_each = [var.alb_listener_rule[count.index].host_header]
-
-    content {
-      host_header {
-        values = condition.value
-      }
-    }
-  }
 }

--- a/ecs/alb.tf
+++ b/ecs/alb.tf
@@ -52,7 +52,7 @@ resource "aws_alb_listener_certificate" "https" {
 resource "aws_lb_listener_rule" "main" {
   count = length(var.alb_listener_rule)
 
-  listener_arn = aws_lb_listener.https.arn
+  listener_arn = aws_alb_listener.https.arn
   priority     = var.alb_listener_rule[count.index].priority
 
   action {

--- a/ecs/alb.tf
+++ b/ecs/alb.tf
@@ -50,7 +50,7 @@ resource "aws_alb_listener_certificate" "https" {
 }
 
 resource "aws_lb_listener_rule" "main" {
-  for_each = { for idx, rule in var.alb_listener_rule : idx => rule }
+  for_each = { for idx, rule in var.alb_listener_rules : idx => rule }
 
   listener_arn = aws_alb_listener.https.arn
   priority     = each.value.priority

--- a/ecs/alb.tf
+++ b/ecs/alb.tf
@@ -63,16 +63,20 @@ resource "aws_lb_listener_rule" "main" {
   dynamic "condition" {
     for_each = [var.alb_listener_rule[count.index].path_pattern]
 
-    path_pattern {
-      values = condition.value
+    content {
+      path_pattern {
+        values = condition.value
+      }
     }
   }
 
   dynamic "condition" {
     for_each = [var.alb_listener_rule[count.index].host_header]
 
-    path_pattern {
-      values = condition.value
+    content {
+      host_header {
+        values = condition.value
+      }
     }
   }
 }

--- a/ecs/alb.tf
+++ b/ecs/alb.tf
@@ -50,18 +50,18 @@ resource "aws_alb_listener_certificate" "https" {
 }
 
 resource "aws_lb_listener_rule" "main" {
-  count = length(var.alb_listener_rule)
+  for_each = { for idx, rule in var.alb_listener_rule : idx => rule }
 
   listener_arn = aws_alb_listener.https.arn
-  priority     = var.alb_listener_rule[count.index].priority
+  priority     = each.value.priority
 
   action {
-    type             = var.alb_listener_rule[count.index].type
-    target_group_arn = var.alb_listener_rule[count.index].target_group_arn
+    type             = each.value.type
+    target_group_arn = each.value.target_group_arn
   }
 
   dynamic "condition" {
-    for_each = [var.alb_listener_rule[count.index].path_pattern]
+    for_each = [each.value.path_pattern]
 
     content {
       path_pattern {

--- a/ecs/alb.tf
+++ b/ecs/alb.tf
@@ -48,3 +48,23 @@ resource "aws_alb_listener_certificate" "https" {
   listener_arn    = aws_alb_listener.https.arn
   certificate_arn = each.value.arn
 }
+
+resource "aws_lb_listener_rule" "main" {
+  count = length(var.alb_listener_rule)
+
+  listener_arn = aws_lb_listener.https.arn
+  priority     = var.alb_listener_rule[count.index].priority
+
+  action {
+    type             = var.alb_listener_rule[count.index].type
+    target_group_arn = var.alb_listener_rule[count.index].target_group_arn
+  }
+
+  condition {
+    for_each = [var.alb_listener_rule[count.index].path_pattern]
+
+    path_pattern {
+      values = condition.value
+    }
+  }
+}

--- a/ecs/alb.tf
+++ b/ecs/alb.tf
@@ -60,8 +60,16 @@ resource "aws_lb_listener_rule" "main" {
     target_group_arn = var.alb_listener_rule[count.index].target_group_arn
   }
 
-  condition {
+  dynamic "condition" {
     for_each = [var.alb_listener_rule[count.index].path_pattern]
+
+    path_pattern {
+      values = condition.value
+    }
+  }
+
+  dynamic "condition" {
+    for_each = [var.alb_listener_rule[count.index].host_header]
 
     path_pattern {
       values = condition.value

--- a/ecs/security-groups.tf
+++ b/ecs/security-groups.tf
@@ -77,6 +77,16 @@ resource "aws_security_group_rule" "ecs-lb-3000" {
   source_security_group_id = aws_security_group.alb.id
 }
 
+resource "aws_security_group_rule" "lb" {
+  for_each                 = toset(var.allow_alb_traffic_to_ports)
+  type                     = "ingress"
+  from_port                = each.key
+  to_port                  = each.key
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.ecs.id
+  source_security_group_id = aws_security_group.alb.id
+}
+
 resource "aws_security_group_rule" "ecs-ssh" {
   count             = length(var.allowlisted_ssh_ips) > 0 ? 1 : 0
   type              = "ingress"

--- a/ecs/security-groups.tf
+++ b/ecs/security-groups.tf
@@ -35,8 +35,6 @@ resource "aws_security_group_rule" "lb-https" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
-
-
 # ECS cluster should only be able to receive traffic to container ports from the ALB
 resource "aws_security_group" "ecs" {
   vpc_id = var.vpc_id

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -164,4 +164,5 @@ variable "alb_listener_rule" {
     target_group_arn = string
     path_pattern     = optional(list(string), [])
   }))
+  default = []
 }

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -157,7 +157,7 @@ variable "cloudwatch_logs_retention_in_days" {
   default = 90
 }
 
-variable "alb_listener_rule" {
+variable "alb_listener_rules" {
   type = list(object({
     priority         = string
     type             = string

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -32,6 +32,11 @@ variable "allow_internal_traffic_to_ports" {
   default = []
 }
 
+variable "allow_alb_traffic_to_ports" {
+  type    = list(string)
+  default = []
+}
+
 # Public subnets are where forwarders run, such as a bastion, NAT or proxy
 variable "subnet_public_ids" { type = list(string) }
 

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -146,7 +146,7 @@ variable "alb_listener_rule" {
     priority         = string
     type             = string
     target_group_arn = string
-    path_pattern     = list(string)
-    host_header      = list(string)
+    path_pattern     = optional(list(string), [])
+    host_header      = optional(list(string), [])
   }))
 }

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -140,3 +140,13 @@ variable "cloudwatch_logs_retention_in_days" {
   type    = number
   default = 90
 }
+
+variable "alb_listener_rule" {
+  type = list(object({
+    priority         = string
+    type             = string
+    target_group_arn = string
+    path_pattern     = list(string)
+    host_header      = list(string)
+  }))
+}

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -1,6 +1,14 @@
-variable "environment" {}
-variable "project" {}
-variable "vpc_id" {}
+variable "environment" {
+  type = string
+}
+
+variable "project" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
 
 # A custom name overrides the default {project}-{environment} convention
 variable "name" {
@@ -24,9 +32,6 @@ variable "allow_internal_traffic_to_ports" {
   default = []
 }
 
-# Private IPs are where the app containers run
-variable "subnet_private_ids" { type = list(string) }
-
 # Public subnets are where forwarders run, such as a bastion, NAT or proxy
 variable "subnet_public_ids" { type = list(string) }
 
@@ -42,7 +47,9 @@ variable "kms_key_arns" {
 
 # Sets the certficate for https traffic into the cluster
 # If not passed, no SSL endpoint will be setup
-variable "certificate_arn" {}
+variable "certificate_arn" {
+  type = string
+}
 
 variable "additional_certificate_arns" {
   description = "Additional certificates to add to the load balancer"
@@ -68,18 +75,22 @@ variable "health_check_path" {
 }
 
 variable "grant_read_access_to_s3_arns" {
+  type    = list(string)
   default = []
 }
 
 variable "grant_write_access_to_s3_arns" {
   default = []
+  type    = list(string)
 }
 
 variable "grant_read_access_to_sqs_arns" {
+  type    = list(string)
   default = []
 }
 
 variable "grant_write_access_to_sqs_arns" {
+  type    = list(string)
   default = []
 }
 

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -158,6 +158,5 @@ variable "alb_listener_rule" {
     type             = string
     target_group_arn = string
     path_pattern     = optional(list(string), [])
-    host_header      = optional(list(string), [])
   }))
 }

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -143,7 +143,7 @@ module "stack" {
   # ECS
   allow_internal_traffic_to_ports = []
   allow_alb_traffic_to_ports = [5000]
-  alb_listener_rule = [
+  alb_listener_rules = [
     {
       priority         = 1
       type             = "forward"

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -9,7 +9,6 @@ module "ecs" {
   project            = var.project
   environment        = var.environment
   vpc_id             = module.vpc.id
-  subnet_private_ids = module.vpc.subnet_private_ids
   subnet_public_ids  = module.vpc.subnet_public_ids
   secrets_arns = flatten([
     data.aws_secretsmanager_secret.app.arn,

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -34,7 +34,6 @@ module "ecs" {
   allow_alb_traffic_to_ports      = var.allow_alb_traffic_to_ports
   alb_listener_rule               = var.alb_listener_rule
 
-
   allowlisted_ssh_ips = distinct(flatten(concat([
     var.allowlisted_ssh_ips,
     var.vpc_cidr_block

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -6,10 +6,10 @@ data "aws_acm_certificate" "default" {
 module "ecs" {
   source = "../../ecs"
 
-  project            = var.project
-  environment        = var.environment
-  vpc_id             = module.vpc.id
-  subnet_public_ids  = module.vpc.subnet_public_ids
+  project           = var.project
+  environment       = var.environment
+  vpc_id            = module.vpc.id
+  subnet_public_ids = module.vpc.subnet_public_ids
   secrets_arns = flatten([
     data.aws_secretsmanager_secret.app.arn,
     var.secret_arns

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -31,7 +31,7 @@ module "ecs" {
 
   allow_internal_traffic_to_ports = var.allow_internal_traffic_to_ports
   allow_alb_traffic_to_ports      = var.allow_alb_traffic_to_ports
-  alb_listener_rule               = var.alb_listener_rule
+  alb_listener_rules              = var.alb_listener_rules
 
   allowlisted_ssh_ips = distinct(flatten(concat([
     var.allowlisted_ssh_ips,

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -31,6 +31,9 @@ module "ecs" {
   region                      = var.region   # used for e.g CloudWatch metrics
 
   allow_internal_traffic_to_ports = var.allow_internal_traffic_to_ports
+  allow_alb_traffic_to_ports      = var.allow_alb_traffic_to_ports
+  alb_listener_rule               = var.alb_listener_rule
+
 
   allowlisted_ssh_ips = distinct(flatten(concat([
     var.allowlisted_ssh_ips,

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -291,6 +291,22 @@ variable "allow_internal_traffic_to_ports" {
   default = []
 }
 
+variable "allow_alb_traffic_to_ports" {
+  type    = list(string)
+  default = []
+}
+
+variable "alb_listener_rule" {
+  type = list(object({
+    priority         = string
+    type             = string
+    target_group_arn = string
+    path_pattern     = optional(list(string), [])
+  }))
+  default = []
+}
+
+
 variable "ecs_name" {
   type    = string
   default = null
@@ -302,18 +318,22 @@ variable "allowlisted_ssh_ips" {
 }
 
 variable "grant_read_access_to_s3_arns" {
+  type    = list(string)
   default = []
 }
 
 variable "grant_write_access_to_s3_arns" {
+  type    = list(string)
   default = []
 }
 
 variable "grant_write_access_to_sqs_arns" {
+  type    = list(string)
   default = []
 }
 
 variable "grant_read_access_to_sqs_arns" {
+  type    = list(string)
   default = []
 }
 
@@ -332,6 +352,7 @@ variable "additional_certificate_arns" {
 }
 
 variable "secret_arns" {
+  type        = list(string)
   description = "arns of the secret manager that ECS can access"
   default     = []
 }

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -296,7 +296,7 @@ variable "allow_alb_traffic_to_ports" {
   default = []
 }
 
-variable "alb_listener_rule" {
+variable "alb_listener_rules" {
   type = list(object({
     priority         = string
     type             = string


### PR DESCRIPTION
#### Summary
- ecs-deploy: add aws_lb_target_group_arn and allow configuration of load_balancer block
- ecs, stack/app: add alb_listener_rule and allow_alb_traffic_to_ports options


