### PR TITLE
Allow creating a stack module without database

### DIFF
--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -118,6 +118,7 @@ module "stack" {
   kms_deletion_window_in_days = 30
 
   # RDS
+  skip_rds               = false # a replicated stack might not need a DB
   rds_instance_class     = "db.t3.micro"
   rds_engine_version     = "13"
   rds_allocated_storage  = 100

--- a/stack/app/README.md
+++ b/stack/app/README.md
@@ -118,11 +118,12 @@ module "stack" {
   kms_deletion_window_in_days = 30
 
   # RDS
-  skip_rds               = false # a replicated stack might not need a DB
-  rds_instance_class     = "db.t3.micro"
-  rds_engine_version     = "13"
-  rds_allocated_storage  = 100
-  rds_multi_az           = true
+  skip_rds                = false # a replicated stack might not need a DB
+  rds_skip_final_snapshot = false
+  rds_instance_class      = "db.t3.micro"
+  rds_engine_version      = "13"
+  rds_allocated_storage   = 100
+  rds_multi_az            = true
 
   ## set these, if you want to create a read-replica instead of a master DB
   ## the master-instance-arn MUST be the ARN of the DB, if the master DB is in

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -68,7 +68,7 @@ module "cloudwatch" {
   project                   = var.project
   environment               = var.environment
   cluster_names             = distinct(concat([module.ecs.ecs_cluster_name], var.cloudwatch_cluster_names))
-  database_identifiers      = distinct(concat([module.rds.database_identifier], var.cloudwatch_database_identifiers))
+  database_identifiers      = distinct(concat([module.rds[0].database_identifier], var.cloudwatch_database_identifiers))
   alb_arn_suffixes          = distinct(concat([module.ecs.alb_arn_suffix], var.cloudwatch_alb_arn_suffixes))
   elasticache_cluster_names = var.skip_elasticache ? [] : distinct(concat([module.elasticache[0].cluster_name], var.cloudwatch_elasticache_names))
 

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -68,7 +68,7 @@ module "cloudwatch" {
   project                   = var.project
   environment               = var.environment
   cluster_names             = distinct(concat([module.ecs.ecs_cluster_name], var.cloudwatch_cluster_names))
-  database_identifiers      = distinct(concat([module.rds[0].database_identifier], var.cloudwatch_database_identifiers))
+  database_identifiers      = distinct(concat([try(module.rds[0].database_identifier, null)], var.cloudwatch_database_identifiers))
   alb_arn_suffixes          = distinct(concat([module.ecs.alb_arn_suffix], var.cloudwatch_alb_arn_suffixes))
   elasticache_cluster_names = var.skip_elasticache ? [] : distinct(concat([module.elasticache[0].cluster_name], var.cloudwatch_elasticache_names))
 

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -68,7 +68,7 @@ module "cloudwatch" {
   project                   = var.project
   environment               = var.environment
   cluster_names             = distinct(concat([module.ecs.ecs_cluster_name], var.cloudwatch_cluster_names))
-  database_identifiers      = distinct(concat([try(module.rds[0].database_identifier, null)], var.cloudwatch_database_identifiers))
+  database_identifiers      = var.skip_rds ? [] : distinct(concat([module.rds[0].database_identifier], var.cloudwatch_database_identifiers))
   alb_arn_suffixes          = distinct(concat([module.ecs.alb_arn_suffix], var.cloudwatch_alb_arn_suffixes))
   elasticache_cluster_names = var.skip_elasticache ? [] : distinct(concat([module.elasticache[0].cluster_name], var.cloudwatch_elasticache_names))
 

--- a/stack/app/outputs.tf
+++ b/stack/app/outputs.tf
@@ -1,9 +1,9 @@
 output "database_url" {
-  value = module.rds.database_url
+  value = var.skip_rds ? "" : module.rds[0].database_url
 }
 
 output "database_arn" {
-  value = module.rds.database_arn
+  value = var.skip_rds ? "" : module.rds[0].database_arn
 }
 
 output "redis_url" {
@@ -46,15 +46,15 @@ output "nlb_target_group_ecs_arn" {
 
 # When launching a stack with a read replica
 output "accept_status-requester" {
-  value = var.rds_is_read_replica ? join("", module.vpc-peering.*.accept_status-requester) : "VPC peering not enabled."
+  value = (var.rds_is_read_replica && !var.skip_rds) ? join("", module.vpc-peering.*.accept_status-requester) : "VPC peering not enabled."
 }
 
 output "accept_status-accepter" {
-  value = var.rds_is_read_replica ? join("", module.vpc-peering.*.accept_status-accepter) : "VPC peering not enabled."
+  value = (var.rds_is_read_replica && !var.skip_rds) ? join("", module.vpc-peering.*.accept_status-accepter) : "VPC peering not enabled."
 }
 
 output "rds_kms_key_arn" {
-  value = var.rds_master_db_kms_key_arn == null ? join("", module.rds-kms-key.*.arn) : "KMS ARN only printed for the master DB to be passed to each replica."
+  value = (var.rds_master_db_kms_key_arn != null || var.skip_rds) ? "KMS ARN only printed for the master DB to be passed to each replica." : join("", module.rds-kms-key.*.arn)
 }
 
 output "ecs_cluster_name" {

--- a/stack/app/outputs.tf
+++ b/stack/app/outputs.tf
@@ -46,11 +46,11 @@ output "nlb_target_group_ecs_arn" {
 
 # When launching a stack with a read replica
 output "accept_status-requester" {
-  value = (var.rds_is_read_replica && !var.skip_rds) ? join("", module.vpc-peering.*.accept_status-requester) : "VPC peering not enabled."
+  value = var.rds_is_read_replica ? join("", module.vpc-peering.*.accept_status-requester) : "VPC peering not enabled."
 }
 
 output "accept_status-accepter" {
-  value = (var.rds_is_read_replica && !var.skip_rds) ? join("", module.vpc-peering.*.accept_status-accepter) : "VPC peering not enabled."
+  value = var.rds_is_read_replica ? join("", module.vpc-peering.*.accept_status-accepter) : "VPC peering not enabled."
 }
 
 output "rds_kms_key_arn" {

--- a/stack/app/rds.tf
+++ b/stack/app/rds.tf
@@ -1,6 +1,6 @@
 module "rds-kms-key" {
   source = "../../kms-key"
-  count  = var.rds_master_db_kms_key_arn == null ? 1 : 0
+  count  = (var.rds_master_db_kms_key_arn != null || var.skip_rds) ? 0 : 1
 
   # Required
   environment = var.environment
@@ -15,6 +15,7 @@ module "rds-kms-key" {
 
 module "rds" {
   source = "../../rds"
+  count  = var.skip_rds ? 0 : 1
 
   depends_on = [
     module.ecs

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -203,6 +203,11 @@ variable "elasticache_automatic_failover_enabled" {
 # =============== Elasticache ================ #
 
 # =============== RDS ================ #
+variable "skip_rds" {
+  type    = bool
+  default = false
+}
+
 variable "rds_name" {
   type    = string
   default = null


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

Allow launching a `stack` module without a database

#### Motivation

We want a replication stack to move compute resources closer to clients, but due to data privacy issues in that geo region, we do not want to have a copy of the database in that geo region.

Has been tested ✅ 


⚠️ on update, you will need to move the terraform state of an existing database, since the pointer changed from something like `module.stack.module.rds.arn` to `module.stack.module.rds[0].arn`.