### PR TITLE
ecs/autoscaling: Fix autoscaling

### DIFF
--- a/autoscaling/ecs/variables.tf
+++ b/autoscaling/ecs/variables.tf
@@ -106,7 +106,7 @@ variable "autoscale_metrics" {
     threshold_up   = optional(number, null) # Threshold of which ECS should start to scale up. If null, would not be included in the scale up alarm
     threshold_down = optional(number, null) # Threshold of which ECS should start to scale down. If null, would not be included in the scale down alarm
     namespace      = optional(string, "AWS/ECS")
-    dimensions     = optional(map(string), {})
+    dimensions     = optional(map(string), null)
   }))
   default = []
 }

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -146,7 +146,7 @@ variable "autoscale_metrics_map" {
       threshold_up   = optional(number, null) # Threshold of which ECS should start to scale up. If null, would not be included in the scale up alarm
       threshold_down = optional(number, null) # Threshold of which ECS should start to scale down. If null, would not be included in the scale down alarm
       namespace      = optional(string, "AWS/ECS")
-      dimensions     = optional(map(string), {})
+      dimensions     = optional(map(string), null)
     }))
   }))
   default = {}

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -408,7 +408,7 @@ variable "autoscale_metrics_map" {
       threshold_up   = optional(number, null) # Threshold of which ECS should start to scale up. If null, would not be included in the scale up alarm
       threshold_down = optional(number, null) # Threshold of which ECS should start to scale down. If null, would not be included in the scale down alarm
       namespace      = optional(string, "AWS/ECS")
-      dimensions     = optional(map(string), {})
+      dimensions     = optional(map(string), null)
     }))
   }))
   default = {}


### PR DESCRIPTION
#### Summary
The default value for dimensions should be null, and not {}

