### PR TITLE
ecs-deploy: ignore desired_count after the aws_ecs_service creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ This project does not follow SemVer, since modules are independent of each other
 ### ecs-task
 - Add new ecs task module
 
+### ecs-deploy
+- Ignore desired_count after the aws_ecs_service creation. [#223](https://github.com/dbl-works/terraform/pull/223)
+
+### ecs-autoscaling
+- Fix the default value of autoscale_metrics -> dimensions. [#222](https://github.com/dbl-works/terraform/pull/222)
+
 ### rds
 - Add identifier as variable [#218](https://github.com/dbl-works/terraform/pull/218)
 

--- a/ecs-deploy/ecs_service.tf
+++ b/ecs-deploy/ecs_service.tf
@@ -82,4 +82,10 @@ resource "aws_ecs_service" "main" {
     Project     = var.project
     Environment = var.environment
   }
+
+  lifecycle {
+    ignore_changes = [
+      desired_count # We should not care about the desired count after the first deployment
+    ]
+  }
 }


### PR DESCRIPTION
#### Summary
Ignore desired_count after the aws_ecs_service creation.

#### Motivation
Terraform apply should not affect the current number of task count triggered by autoscaling

