### PR TITLE
[FIX] S3 Private: The bucket does not allow ACLs

### DIFF
--- a/s3-private/s3.tf
+++ b/s3-private/s3.tf
@@ -38,6 +38,11 @@ resource "aws_s3_bucket_cors_configuration" "main-bucket-cors-configuration" {
 resource "aws_s3_bucket_acl" "main-bucket-data-acl" {
   bucket = module.s3.id
   acl    = "private"
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.main,
+    aws_s3_bucket_public_access_block.main
+  ]
 }
 
 # https://aws.amazon.com/about-aws/whats-new/2021/11/amazon-s3-object-ownership-simplify-access-management-data-s3/

--- a/s3-private/s3.tf
+++ b/s3-private/s3.tf
@@ -41,7 +41,7 @@ resource "aws_s3_bucket_acl" "main-bucket-data-acl" {
 
   depends_on = [
     aws_s3_bucket_ownership_controls.main,
-    aws_s3_bucket_public_access_block.main
+    aws_s3_bucket_public_access_block.block-all-access
   ]
 }
 

--- a/s3-private/s3.tf
+++ b/s3-private/s3.tf
@@ -52,7 +52,6 @@ resource "aws_s3_bucket_ownership_controls" "main" {
   rule {
     object_ownership = "BucketOwnerPreferred"
   }
-  depends_on = [aws_s3_bucket_acl.main-bucket-data-acl]
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "main-bucket-sse-configuration" {


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

Fixes The bucket does not allow ACLs
Which is broken due to updates from AWS to how S3 works.

#### Motivation

tested: create a new private bucket with default settings -> works ✅
