### PR TITLE
RDS: less logging

### DIFF
--- a/rds/parameter-group.tf
+++ b/rds/parameter-group.tf
@@ -6,7 +6,7 @@ resource "aws_db_parameter_group" "current" {
 
   parameter {
     name  = "log_statement"
-    value = "all"
+    value = "ddl" # Logs all data definition language (DDL) statements, such as CREATE, ALTER, DROP, and so on.
   }
   parameter {
     name  = "log_min_duration_statement"

--- a/rds/parameter-group.tf
+++ b/rds/parameter-group.tf
@@ -13,6 +13,11 @@ resource "aws_db_parameter_group" "current" {
     value = "0"
   }
   parameter {
+    name  = "rds.log_retention_period"
+    value = 4320 # in minutes, must be between 1440-10080 (1-7 days)
+  }
+
+  parameter {
     name  = "rds.force_ssl"
     value = 1
   }


### PR DESCRIPTION
#### Summary
- only log DDL not everything on the DB
- set log retention to 3 days


#### Motivation


Prior to this PR, RDS would log every statement, including select statements.

This can lead to serious amounts of logs collected during traffic spikes.

In one app, this caused 390 GiB of logs to be produced within 24 hours.

Increasing storage beyond 400 GiB is not a fast solution: https://repost.aws/knowledge-center/rds-stuck-modifying
