### PR TITLE
[Chore] Set log statement to none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project does not follow SemVer, since modules are independent of each other
 
 ### rds
 - Add identifier as variable [#218](https://github.com/dbl-works/terraform/pull/218)
+- Set log_statement to none [#227](https://github.com/dbl-works/terraform/pull/227)
 
 ### s3-public
 - Add public bucket configuration to avoid ACCESS DENIED error. [#218](https://github.com/dbl-works/terraform/pull/218)

--- a/rds/parameter-group.tf
+++ b/rds/parameter-group.tf
@@ -6,7 +6,7 @@ resource "aws_db_parameter_group" "current" {
 
   parameter {
     name  = "log_statement"
-    value = "ddl" # Logs all data definition language (DDL) statements, such as CREATE, ALTER, DROP, and so on.
+    value = "none" # Logs nothing
   }
   parameter {
     name  = "log_min_duration_statement"


### PR DESCRIPTION
#### Summary
Set log_statement to none since logs are seldom to be used for debugging purpose and it will also expose the password upon creation of role/user


#### Motivation
Reduce the storage consumption in RDS

