### PR TITLE
Set Load Balancer keep alive timeout to 60 seconds

### DIFF
--- a/ecs/README.md
+++ b/ecs/README.md
@@ -4,7 +4,7 @@ Create a compute cluster for hosting docker based apps.
 
 ## Notes
 
-The `idle_timeout` is set to 60 seconds. Make sure that your webserver's keep-alive timeout is set to 60 seconds (or more) to prevent the load balancer from keeping connections open to that the server has already closed.
+The `idle_timeout` is set to 60 seconds. Ensure that your webserver's keep-alive timeout is set to 60 seconds (or more) to prevent the load balancer from keeping connections open to the already closed server.
 
 When using Rails with Puma, the default timeout is 20 seconds. This can be changed by setting the `persistent_timeout` option in `config/puma.rb`.
 

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -2,7 +2,11 @@
 
 Create a compute cluster for hosting docker based apps.
 
+## Notes
 
+The `idle_timeout` is set to 60 seconds. Make sure that your webserver's keep-alive timeout is set to 60 seconds (or more) to prevent the load balancer from keeping connections open to that the server has already closed.
+
+When using Rails with Puma, the default timeout is 20 seconds. This can be changed by setting the `persistent_timeout` option in `config/puma.rb`.
 
 ## Usage
 

--- a/ecs/alb.tf
+++ b/ecs/alb.tf
@@ -6,7 +6,7 @@ resource "aws_alb" "alb" {
     aws_security_group.alb.id,
   ]
   enable_http2 = "true"
-  idle_timeout = 600
+  idle_timeout = 60 # The time in seconds that the connection is allowed to be idle.
   tags = {
     Name        = "${var.project}-${var.environment}"
     Project     = var.project


### PR DESCRIPTION
#### Summary

The current setting of 10 minutes is too long. The default is 60, which we should keep.

Rails /w Puma apps even default to 20 seconds. If you were to use a Ruby/Puma server with its default settings, having the LB keep connections open for more than 20 seconds 
will lead to bugs.

Also see https://github.com/puma/puma/issues/957

The update can be done in-place
<img width="801" alt="image" src="https://github.com/dbl-works/terraform/assets/20702503/7377ce14-07fc-415e-b940-d3aef4d67e57">


#### Motivation

<!-- Why are you making this change? -->
