### PR TITLE
ecs-deploy: enable deployment circuit breaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project does not follow SemVer, since modules are independent of each other
 
 ## Unreleased
 ### ecs-deploy
+- Add deployment_circuit_breaker options [#230](https://github.com/dbl-works/terraform/pull/230)
+
+## [v2023.07.19]
+### ecs-deploy
 - Allow ecs service to be deployed to private subnets. [#228](https://github.com/dbl-works/terraform/pull/228)
 
 ### fivetran/connectors/lambda
@@ -35,6 +39,7 @@ This project does not follow SemVer, since modules are independent of each other
 
 ### ecs
 - add alb_listener_rule and allow_alb_traffic_to_ports options, remove subnet_private_ids since it is not used [#216](https://github.com/dbl-works/terraform/pull/216)
+- Set Load Balancer keep alive timeout to 60 seconds [#229](https://github.com/dbl-works/terraform/pull/229)
 
 ### stack/app
 - add alb_listener_rule and allow_alb_traffic_to_ports options [#216](https://github.com/dbl-works/terraform/pull/216)

--- a/ecs-deploy/ecs_service.tf
+++ b/ecs-deploy/ecs_service.tf
@@ -53,6 +53,11 @@ resource "aws_ecs_service" "main" {
   desired_count   = var.desired_count
   launch_type     = "FARGATE"
 
+  deployment_circuit_breaker {
+    enable   = var.deployment_circuit_breaker.enable
+    rollback = var.deployment_circuit_breaker.rollback
+  }
+
   network_configuration {
     subnets = data.aws_subnets.selected.ids
 

--- a/ecs-deploy/variables.tf
+++ b/ecs-deploy/variables.tf
@@ -131,3 +131,10 @@ variable "aws_lb_target_group_arn" {
   type    = string
   default = null
 }
+
+variable "deployment_circuit_breaker" {
+  type = object({
+    enable   = optional(bool, true)
+    rollback = optional(bool, true)
+  })
+}

--- a/ecs-deploy/variables.tf
+++ b/ecs-deploy/variables.tf
@@ -137,5 +137,8 @@ variable "deployment_circuit_breaker" {
     enable   = optional(bool, true)
     rollback = optional(bool, true)
   })
-  default = null
+  default = {
+    enable   = true
+    rollback = true
+  }
 }

--- a/ecs-deploy/variables.tf
+++ b/ecs-deploy/variables.tf
@@ -137,4 +137,5 @@ variable "deployment_circuit_breaker" {
     enable   = optional(bool, true)
     rollback = optional(bool, true)
   })
+  default = {}
 }

--- a/ecs-deploy/variables.tf
+++ b/ecs-deploy/variables.tf
@@ -137,5 +137,5 @@ variable "deployment_circuit_breaker" {
     enable   = optional(bool, true)
     rollback = optional(bool, true)
   })
-  default = {}
+  default = null
 }


### PR DESCRIPTION
#### Summary
- Enable deployment circuit breaker
- Watch this [video](https://www.youtube.com/watch?v=Y2Ez9M7A95Y) to understand what is it
- AWS Docs: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-circuit-breaker.html
- The ways the deployment circuit breaker calculates the failure threshold (when it marks the deployment as FAILED)
  - See [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-circuit-breaker.html#failure-threshold)

#### Motivation
- Preventing an excessive number of failures during a new deployment. 
- This feature will also send an event notification once the deployment is failing, which will allow us to create an alert based on it
