### PR TITLE
enable in transit encryption for elasticache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project does not follow SemVer, since modules are independent of each other
 ### ecs-deploy
 - Add deployment_circuit_breaker options [#230](https://github.com/dbl-works/terraform/pull/230)
 
+### elasticache
+- Enable `encryption-in-transit` by default [#231](https://github.com/dbl-works/terraform/pull/231)
+- Change default Redis version from `6` to `7` [#231](https://github.com/dbl-works/terraform/pull/231)
+
 ## [v2023.07.19]
 ### ecs-deploy
 - Allow ecs service to be deployed to private subnets. [#228](https://github.com/dbl-works/terraform/pull/228)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project does not follow SemVer, since modules are independent of each other
 - Add deployment_circuit_breaker options [#230](https://github.com/dbl-works/terraform/pull/230)
 
 ### elasticache
-- Enable `encryption-in-transit` by default [#231](https://github.com/dbl-works/terraform/pull/231)
+- Enable `encryption-in-transit` by default, :warning: requires re-creation of the cluster (you can thus opt-out) [#231](https://github.com/dbl-works/terraform/pull/231)
 - Change default Redis version from `6` to `7` [#231](https://github.com/dbl-works/terraform/pull/231)
 
 ## [v2023.07.19]

--- a/elasticache/README.md
+++ b/elasticache/README.md
@@ -23,7 +23,7 @@ module "elasticache" {
   # optional
   name                 = null # pass e.g. "sidekiq" to append this to all names when you launch a 2nd Redis cluster for Sidekiq (see below)
   node_type            = "cache.t3.micro"
-  engine_version       = "6.x"
+  major_version        = 7
   cluster_mode         = true
   data_tiering_enabled = false # only available for "r6gd" node types (see warning below)
   multi_az_enabled     = true # requires at least 1 replica

--- a/elasticache/README.md
+++ b/elasticache/README.md
@@ -26,7 +26,7 @@ module "elasticache" {
   major_version              = 7
   minor_version              = 0
   cluster_mode               = true
-  transit_encryption_enabled = true # changing this requires re-creation of the cluster
+  transit_encryption_enabled = true # changing this requires re-creation of the cluster, NOTE: use `rediss://` as the protocol in your application when TLS is enabled
   data_tiering_enabled       = false # only available for "r6gd" node types (see warning below)
   multi_az_enabled           = true # requires at least 1 replica
   maxmemory_policy           = "noeviction" # Allowed values: volatile-lru,allkeys-lru,volatile-lfu,allkeys-lfu,volatile-random,allkeys-random,volatile-ttl,noeviction

--- a/elasticache/README.md
+++ b/elasticache/README.md
@@ -2,8 +2,6 @@
 
 A repository for setting up an elasticache cluster.
 
-
-
 ## Usage
 
 ```terraform
@@ -33,7 +31,7 @@ module "elasticache" {
 
   # To enable cluster mode, use a parameter group that has cluster mode enabled.
   # The default parameter groups provided by AWS end with ".cluster.on", for example default.redis6.x.cluster.on.
-  parameter_group_name = "default.redis6.x"
+  parameter_group_name = "default.redis6.x" # if omitted, a custom parameter group will be created by this module. Must be omitted for `maxmemory_policy` to be effective.
 
   # Number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them.
   # If the value of snapshot_retention_limit is set to zero (0), backups are turned off.
@@ -46,12 +44,13 @@ module "elasticache" {
 }
 ```
 
-
 Sidekiq does not work with cluster mode. The recommended setup is to have:
+
 * one Redis cluster (cluster-mode on) for caching
 * one Redis cluster (cluster-mode off) for Sidekiq
 
 :warning: If the node type is from the `r6gd` family, be aware that availability is limited to the following regions:
+
 * us-east-2, us-east-1
 * us-west-2, us-west-1, eu-west-1
 * eu-central-1
@@ -63,8 +62,6 @@ Sidekiq does not work with cluster mode. The recommended setup is to have:
 
 As of July 2022. Also, you **must** use Reds `6.2` or later.
 
-
-
 ## Outputs
 
-- `endpoint`
+* `endpoint`

--- a/elasticache/README.md
+++ b/elasticache/README.md
@@ -21,13 +21,14 @@ module "elasticache" {
   node_count = 1
 
   # optional
-  name                 = null # pass e.g. "sidekiq" to append this to all names when you launch a 2nd Redis cluster for Sidekiq (see below)
-  node_type            = "cache.t3.micro"
-  major_version        = 7
-  cluster_mode         = true
-  data_tiering_enabled = false # only available for "r6gd" node types (see warning below)
-  multi_az_enabled     = true # requires at least 1 replica
-  maxmemory_policy     = "noeviction" # Allowed values: volatile-lru,allkeys-lru,volatile-lfu,allkeys-lfu,volatile-random,allkeys-random,volatile-ttl,noeviction
+  name                       = null # pass e.g. "sidekiq" to append this to all names when you launch a 2nd Redis cluster for Sidekiq (see below)
+  node_type                  = "cache.t3.micro"
+  major_version              = 7
+  cluster_mode               = true
+  transit_encryption_enabled = true # changing this requires re-creation of the cluster
+  data_tiering_enabled       = false # only available for "r6gd" node types (see warning below)
+  multi_az_enabled           = true # requires at least 1 replica
+  maxmemory_policy           = "noeviction" # Allowed values: volatile-lru,allkeys-lru,volatile-lfu,allkeys-lfu,volatile-random,allkeys-random,volatile-ttl,noeviction
 
   # To enable cluster mode, use a parameter group that has cluster mode enabled.
   # The default parameter groups provided by AWS end with ".cluster.on", for example default.redis6.x.cluster.on.

--- a/elasticache/README.md
+++ b/elasticache/README.md
@@ -31,7 +31,7 @@ module "elasticache" {
 
   # To enable cluster mode, use a parameter group that has cluster mode enabled.
   # The default parameter groups provided by AWS end with ".cluster.on", for example default.redis6.x.cluster.on.
-  parameter_group_name = "default.redis6.x" # if omitted, a custom parameter group will be created by this module. Must be omitted for `maxmemory_policy` to be effective.
+  parameter_group_name = null # e.g. "default.redis7.x", if omitted (default), a custom parameter group will be created by this module. Must be omitted for `maxmemory_policy` to be effective.
 
   # Number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them.
   # If the value of snapshot_retention_limit is set to zero (0), backups are turned off.

--- a/elasticache/README.md
+++ b/elasticache/README.md
@@ -24,6 +24,7 @@ module "elasticache" {
   name                       = null # pass e.g. "sidekiq" to append this to all names when you launch a 2nd Redis cluster for Sidekiq (see below)
   node_type                  = "cache.t3.micro"
   major_version              = 7
+  minor_version              = 0
   cluster_mode               = true
   transit_encryption_enabled = true # changing this requires re-creation of the cluster
   data_tiering_enabled       = false # only available for "r6gd" node types (see warning below)

--- a/elasticache/elasticache.tf
+++ b/elasticache/elasticache.tf
@@ -7,7 +7,7 @@ resource "aws_elasticache_replication_group" "non_cluster_mode" {
   num_cache_clusters          = var.node_count
   preferred_cache_cluster_azs = var.availability_zones
   parameter_group_name        = var.parameter_group_name == null ? aws_elasticache_parameter_group.main[0].id : var.parameter_group_name
-  engine_version              = "${var.major_version}.x"
+  engine_version              = var.major_version
   port                        = 6379
   subnet_group_name           = aws_elasticache_subnet_group.main.name
   at_rest_encryption_enabled  = true
@@ -50,7 +50,7 @@ resource "aws_elasticache_replication_group" "cluster_mode" {
   engine                     = "redis"
   node_type                  = var.node_type
   parameter_group_name       = var.parameter_group_name == null ? aws_elasticache_parameter_group.main[0].id : var.parameter_group_name
-  engine_version             = "${var.major_version}.x"
+  engine_version             = var.major_version
   port                       = 6379
   subnet_group_name          = aws_elasticache_subnet_group.main.name
   at_rest_encryption_enabled = true

--- a/elasticache/elasticache.tf
+++ b/elasticache/elasticache.tf
@@ -85,11 +85,8 @@ resource "aws_elasticache_parameter_group" "main" {
   count = var.parameter_group_name == null ? 0 : 1
 
   name = local.cluster_name
-  # Family need to be specified so that we can copy keys n values from the existing parameter group
-  # The regexp will extract the family name from the parameter group name, eg:
-  # default.redis6.x => redis6.x
-  # default.redis6.x.cluster.on => redis6.x
-  family = regex("[A-Za-z]+\\.([A-Za-z0-9]+\\.[A-Za-z0-9]+)", var.parameter_group_name)[0]
+  # format: "redis6.x"
+  family = "redis${var.engine_version}"
 
   parameter {
     name  = "maxmemory-policy"

--- a/elasticache/elasticache.tf
+++ b/elasticache/elasticache.tf
@@ -81,7 +81,7 @@ resource "aws_elasticache_replication_group" "cluster_mode" {
   }
 }
 
-local {
+locals {
   # the format is different for different major Redis versions, see: https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateCacheParameterGroup.html
   family = "redis${var.major_version == 6 ? "6.x" : "7"}"
 

--- a/elasticache/elasticache.tf
+++ b/elasticache/elasticache.tf
@@ -6,7 +6,7 @@ resource "aws_elasticache_replication_group" "non_cluster_mode" {
   node_type                   = var.node_type
   num_cache_clusters          = var.node_count
   preferred_cache_cluster_azs = var.availability_zones
-  parameter_group_name        = var.parameter_group_name != null ? var.parameter_group_name : aws_elasticache_parameter_group.main[0].id
+  parameter_group_name        = var.parameter_group_name == null ? aws_elasticache_parameter_group.main[0].id : var.parameter_group_name
   engine_version              = var.engine_version
   port                        = 6379
   subnet_group_name           = aws_elasticache_subnet_group.main.name
@@ -48,7 +48,7 @@ resource "aws_elasticache_replication_group" "cluster_mode" {
   description                = "Collection of Redis (clusters mode) for ${var.project}-${var.environment}"
   engine                     = "redis"
   node_type                  = var.node_type
-  parameter_group_name       = var.parameter_group_name != null ? var.parameter_group_name : aws_elasticache_parameter_group.main[0].id
+  parameter_group_name       = var.parameter_group_name == null ? aws_elasticache_parameter_group.main[0].id : var.parameter_group_name
   engine_version             = var.engine_version
   port                       = 6379
   subnet_group_name          = aws_elasticache_subnet_group.main.name
@@ -82,7 +82,7 @@ resource "aws_elasticache_replication_group" "cluster_mode" {
 }
 
 resource "aws_elasticache_parameter_group" "main" {
-  count = var.parameter_group_name == null ? 0 : 1
+  count = var.parameter_group_name == null ? 1 : 0
 
   name = local.cluster_name
   # format: "redis6.x"

--- a/elasticache/elasticache.tf
+++ b/elasticache/elasticache.tf
@@ -11,6 +11,7 @@ resource "aws_elasticache_replication_group" "non_cluster_mode" {
   port                        = 6379
   subnet_group_name           = aws_elasticache_subnet_group.main.name
   at_rest_encryption_enabled  = true
+  transit_encryption_enabled  = true
   kms_key_id                  = var.kms_key_arn
   snapshot_retention_limit    = var.snapshot_retention_limit
   # When you change an attribute, such as engine_version,
@@ -53,6 +54,7 @@ resource "aws_elasticache_replication_group" "cluster_mode" {
   port                       = 6379
   subnet_group_name          = aws_elasticache_subnet_group.main.name
   at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
   kms_key_id                 = var.kms_key_arn
   snapshot_retention_limit   = var.snapshot_retention_limit
   apply_immediately          = true
@@ -101,10 +103,5 @@ resource "aws_elasticache_parameter_group" "main" {
   parameter {
     name  = "cluster-enabled"
     value = var.cluster_mode ? "yes" : "no"
-  }
-
-  parameter {
-    name  = "transit-encryption-enabled"
-    value = true
   }
 }

--- a/elasticache/elasticache.tf
+++ b/elasticache/elasticache.tf
@@ -7,7 +7,7 @@ resource "aws_elasticache_replication_group" "non_cluster_mode" {
   num_cache_clusters          = var.node_count
   preferred_cache_cluster_azs = var.availability_zones
   parameter_group_name        = var.parameter_group_name == null ? aws_elasticache_parameter_group.main[0].id : var.parameter_group_name
-  engine_version              = "${var.major_version}.${minor_version}"
+  engine_version              = "${var.major_version}.${var.minor_version}"
   port                        = 6379
   subnet_group_name           = aws_elasticache_subnet_group.main.name
   at_rest_encryption_enabled  = true
@@ -50,7 +50,7 @@ resource "aws_elasticache_replication_group" "cluster_mode" {
   engine                     = "redis"
   node_type                  = var.node_type
   parameter_group_name       = var.parameter_group_name == null ? aws_elasticache_parameter_group.main[0].id : var.parameter_group_name
-  engine_version             = "${var.major_version}.${minor_version}"
+  engine_version             = "${var.major_version}.${var.minor_version}"
   port                       = 6379
   subnet_group_name          = aws_elasticache_subnet_group.main.name
   at_rest_encryption_enabled = true

--- a/elasticache/elasticache.tf
+++ b/elasticache/elasticache.tf
@@ -6,7 +6,7 @@ resource "aws_elasticache_replication_group" "non_cluster_mode" {
   node_type                   = var.node_type
   num_cache_clusters          = var.node_count
   preferred_cache_cluster_azs = var.availability_zones
-  parameter_group_name        = var.maxmemory_policy == null ? var.parameter_group_name : aws_elasticache_parameter_group.main[0].id
+  parameter_group_name        = var.parameter_group_name != null ? var.parameter_group_name : aws_elasticache_parameter_group.main[0].id
   engine_version              = var.engine_version
   port                        = 6379
   subnet_group_name           = aws_elasticache_subnet_group.main.name
@@ -48,7 +48,7 @@ resource "aws_elasticache_replication_group" "cluster_mode" {
   description                = "Collection of Redis (clusters mode) for ${var.project}-${var.environment}"
   engine                     = "redis"
   node_type                  = var.node_type
-  parameter_group_name       = var.maxmemory_policy == null ? var.parameter_group_name : aws_elasticache_parameter_group.main[0].id
+  parameter_group_name       = var.parameter_group_name != null ? var.parameter_group_name : aws_elasticache_parameter_group.main[0].id
   engine_version             = var.engine_version
   port                       = 6379
   subnet_group_name          = aws_elasticache_subnet_group.main.name
@@ -82,7 +82,7 @@ resource "aws_elasticache_replication_group" "cluster_mode" {
 }
 
 resource "aws_elasticache_parameter_group" "main" {
-  count = var.maxmemory_policy == null ? 0 : 1
+  count = var.parameter_group_name == null ? 0 : 1
 
   name = local.cluster_name
   # Family need to be specified so that we can copy keys n values from the existing parameter group
@@ -99,5 +99,10 @@ resource "aws_elasticache_parameter_group" "main" {
   parameter {
     name  = "cluster-enabled"
     value = var.cluster_mode ? "yes" : "no"
+  }
+
+  parameter {
+    name  = "transit-encryption-enabled"
+    value = true
   }
 }

--- a/elasticache/elasticache.tf
+++ b/elasticache/elasticache.tf
@@ -7,7 +7,7 @@ resource "aws_elasticache_replication_group" "non_cluster_mode" {
   num_cache_clusters          = var.node_count
   preferred_cache_cluster_azs = var.availability_zones
   parameter_group_name        = var.parameter_group_name == null ? aws_elasticache_parameter_group.main[0].id : var.parameter_group_name
-  engine_version              = var.major_version
+  engine_version              = "${var.major_version}.${minor_version}"
   port                        = 6379
   subnet_group_name           = aws_elasticache_subnet_group.main.name
   at_rest_encryption_enabled  = true
@@ -50,7 +50,7 @@ resource "aws_elasticache_replication_group" "cluster_mode" {
   engine                     = "redis"
   node_type                  = var.node_type
   parameter_group_name       = var.parameter_group_name == null ? aws_elasticache_parameter_group.main[0].id : var.parameter_group_name
-  engine_version             = var.major_version
+  engine_version             = "${var.major_version}.${minor_version}"
   port                       = 6379
   subnet_group_name          = aws_elasticache_subnet_group.main.name
   at_rest_encryption_enabled = true

--- a/elasticache/variables.tf
+++ b/elasticache/variables.tf
@@ -34,9 +34,13 @@ variable "parameter_group_name" {
   default = null
 }
 
-variable "engine_version" {
-  type    = string
-  default = "7.x"
+variable "major_version" {
+  type    = number
+  default = 7
+  validation {
+    condition     = var.major_version >= 6 && var.major_version <= 7
+    error_message = "major_version must be 6 or 7"
+  }
 }
 
 variable "snapshot_retention_limit" {

--- a/elasticache/variables.tf
+++ b/elasticache/variables.tf
@@ -31,7 +31,7 @@ variable "node_count" {
 
 variable "parameter_group_name" {
   type    = string
-  default = "default.redis6.x"
+  default = null
 }
 
 variable "engine_version" {

--- a/elasticache/variables.tf
+++ b/elasticache/variables.tf
@@ -65,6 +65,12 @@ variable "cluster_mode" {
   default = true
 }
 
+variable "transit_encryption_enabled" {
+  type        = bool
+  default     = true
+  description = ":warning: changing this from `false` to `true` requires a re-creation of the cluster"
+}
+
 variable "multi_az_enabled" {
   type    = bool
   default = true

--- a/elasticache/variables.tf
+++ b/elasticache/variables.tf
@@ -82,8 +82,9 @@ variable "name" {
 }
 
 variable "maxmemory_policy" {
-  type    = string
-  default = null
+  type        = string
+  default     = null
+  description = "Only effective, when NOT passing a custom parameter group name"
 }
 
 locals {

--- a/elasticache/variables.tf
+++ b/elasticache/variables.tf
@@ -43,6 +43,15 @@ variable "major_version" {
   }
 }
 
+variable "minor_version" {
+  type    = number
+  default = 0
+  validation {
+    condition     = var.minor_version >= 0
+    error_message = "minor_version must be between 0 or higher"
+  }
+}
+
 variable "snapshot_retention_limit" {
   type    = number
   default = 0

--- a/elasticache/variables.tf
+++ b/elasticache/variables.tf
@@ -36,7 +36,7 @@ variable "parameter_group_name" {
 
 variable "engine_version" {
   type    = string
-  default = "6.x"
+  default = "7.x"
 }
 
 variable "snapshot_retention_limit" {


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

* create a custom parameter group, if `parameter_group` variable is omitted instead of checking `maxmemory_policy`, since that is more intuitive
* enforce `in-transit-encryption` for better security (requirement of ISO 27001, see https://www.dataguard.co.uk/blog/iso-27001-annex-a.10-cryptography)

https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/in-transit-encryption.html

--> ⚠️ Enabling in-transit encryption is a *breaking* change, i.e., it requires to re-create the Redis cluster. If you need zero downtime, you must create a new cluster, swap endpoints in the app, then destroy the old one. Data loss will occur, though.

see also: https://aquasecurity.github.io/tfsec/v0.61.3/checks/aws/elasticache/enable-in-transit-encryption/

#### Motivation

security (specifically ISO 27001)


--> Tested upgrading from Redis 6 without encryption to Redis 7 with encryption in transit: works ✅ (but requires the cluster to be recreated).
