### PR TITLE
iam/iam-for-deploy-bot: add service discovery access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,12 @@ This project does not follow SemVer, since modules are independent of each other
 ### HTTP Proxy
 - New module to launch a tiny-proxy based HTTP proxy instance to allow an application server to assume a static IP address for outgoing traffic, e.g. when using a third-party API that requires a static IP address. For a robust and scaleable solution, consider using a NAT Gateway instead.
 
+### iam/iam-for-deploy-bot
+- add permissions to manage service discovery [#241](https://github.com/dbl-works/terraform/pull/241)
+
 ## [v2023.07.27]
 ### slack/ecs-deployment-failure
-- New module which send a message to Slack when the deployment is a failure.
+- New module which send a message to Slack when the deployment is a failure. [#235](https://github.com/dbl-works/terraform/pull/235)
 
 ### ecs-deploy
 - Add deployment_circuit_breaker options [#230](https://github.com/dbl-works/terraform/pull/230)

--- a/iam/iam-for-deploy-bot/main.tf
+++ b/iam/iam-for-deploy-bot/main.tf
@@ -183,7 +183,7 @@ resource "aws_iam_group_policy_attachment" "deploy-bot-s3-access" {
   policy_arn = aws_iam_policy.deploy-bot-s3-full-access.arn
 }
 
-resource "aws_iam_group_policy_attachment" "service_discovery_access" {
+resource "aws_iam_group_policy_attachment" "service-discovery-access" {
   group      = aws_iam_group.deploy-bot-deploy-access.name
   policy_arn = aws_iam_policy.service-discovery-access.arn
 }

--- a/iam/iam-for-deploy-bot/main.tf
+++ b/iam/iam-for-deploy-bot/main.tf
@@ -5,7 +5,6 @@ resource "aws_iam_user" "user" {
   }
 }
 
-
 resource "aws_iam_user_group_membership" "memberships" {
   user   = "deploy-bot"
   groups = ["deploy-bot-deploy-access"]
@@ -13,8 +12,6 @@ resource "aws_iam_user_group_membership" "memberships" {
     aws_iam_group.deploy-bot-deploy-access,
   ]
 }
-
-
 
 resource "aws_iam_policy" "deploy-bot-ecr-full-access" {
   name        = "AmazonEC2ContainerRegistryFullAccess"
@@ -142,6 +139,25 @@ resource "aws_iam_policy" "deploy-bot-extra-access" {
   })
 }
 
+resource "aws_iam_policy" "service-discovery-access" {
+  name        = "DeployBot_ServiceDiscoveryAccess"
+  path        = "/"
+  description = "Service Discovery Access"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "servicediscovery:TagResource",
+          "servicediscovery:ListTagsForResource",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
 resource "aws_iam_group_policy_attachment" "deploy-bot-ecs-access" {
   group      = aws_iam_group.deploy-bot-deploy-access.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonECS_FullAccess"
@@ -165,4 +181,9 @@ resource "aws_iam_group_policy_attachment" "deploy-bot-secrets-access" {
 resource "aws_iam_group_policy_attachment" "deploy-bot-s3-access" {
   group      = aws_iam_group.deploy-bot-deploy-access.name
   policy_arn = aws_iam_policy.deploy-bot-s3-full-access.arn
+}
+
+resource "aws_iam_group_policy_attachment" "service_discovery_access" {
+  group      = aws_iam_group.deploy-bot-deploy-access.name
+  policy_arn = aws_iam_policy.service-discovery-access.arn
 }


### PR DESCRIPTION
#### Summary

Add service discovery access to deploybot

#### Motivation

We can easily roll out the service discovery to all projects and deploy using deploybot
