### PR TITLE
stack/app: add elasticache major and minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project does not follow SemVer, since modules are independent of each other
 
 ### stack/app
 - Add service_discovery_enabled as variables. [#240](https://github.com/dbl-works/terraform/pull/240)
+- Add elasticache major and minor version to the module. [#245](https://github.com/dbl-works/terraform/pull/245)
 
 ### iam/iam-for-deploy-bot
 - add permissions to manage service discovery [#241](https://github.com/dbl-works/terraform/pull/241)

--- a/stack/app/elasticache.tf
+++ b/stack/app/elasticache.tf
@@ -15,6 +15,7 @@ module "elasticache" {
 
   # optional
   name                       = var.elasticache_name
+  major_version              = var.elasticache_major_version
   node_type                  = var.elasticache_node_type
   node_count                 = var.elasticache_node_count == null ? (var.elasticache_automatic_failover_enabled ? 2 : 1) : var.elasticache_node_count
   snapshot_retention_limit   = var.elasticache_snapshot_retention_limit

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -155,6 +155,24 @@ variable "elasticache_node_type" {
   default = "cache.t3.micro"
 }
 
+variable "elasticache_major_version" {
+  type    = number
+  default = 7
+  validation {
+    condition     = var.elasticache_major_version >= 6 && var.elasticache_major_version <= 7
+    error_message = "elasticache major_version must be 6 or 7"
+  }
+}
+
+variable "elasticache_minor_version" {
+  type    = number
+  default = 0
+  validation {
+    condition     = var.elasticache_minor_version >= 0
+    error_message = "elasticache minor_version must be between 0 or higher"
+  }
+}
+
 variable "elasticache_node_count" {
   type    = number
   default = 1
@@ -162,7 +180,7 @@ variable "elasticache_node_count" {
 
 variable "elasticache_parameter_group_name" {
   type    = string
-  default = "default.redis6.x.cluster.on"
+  default = "default.redis7.cluster.on"
 }
 
 variable "elasticache_replicas_per_node_group" {


### PR DESCRIPTION
#### Summary
Add elasticache major and minor version to stack/app module

#### Motivation
To create elasticache using stack/app module. Otherwise it will throw error complaining that the version and parameter group is different

