### PR TITLE
rds: add max_allocated_storage variables for rds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 This project does not follow SemVer, since modules are independent of each other; thus, SemVer does not make sense. Changes are grouped per module.
 
 ## Unreleased
+### rds
+- Add max_allocated_storage to rds. [#249](https://github.com/dbl-works/terraform/pull/249)
+
 ### lambda
 - Add lambda_role_arn variables [#236](https://github.com/dbl-works/terraform/pull/236)
 
@@ -19,6 +22,7 @@ This project does not follow SemVer, since modules are independent of each other
 ### stack/app
 - Add service_discovery_enabled as variables. [#240](https://github.com/dbl-works/terraform/pull/240)
 - Add elasticache major and minor version to the module. [#245](https://github.com/dbl-works/terraform/pull/245)
+- Add rds_max_allocated_storage to rds. [#249](https://github.com/dbl-works/terraform/pull/249)
 
 ### iam/iam-for-deploy-bot
 - add permissions to manage service discovery [#241](https://github.com/dbl-works/terraform/pull/241)

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -8,6 +8,7 @@ resource "aws_db_instance" "main" {
   allow_major_version_upgrade         = true
   db_subnet_group_name                = aws_db_subnet_group.main.name
   allocated_storage                   = var.allocated_storage
+  max_allocated_storage               = var.max_allocated_storage
   storage_type                        = "gp2"
   engine                              = var.is_read_replica ? null : "postgres"
   engine_version                      = var.is_read_replica ? null : local.major_engine_version # Use major version only to allow AWS to update the minor/patch version automatically

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -12,6 +12,7 @@ variable "engine_version" {
   type    = string
 }
 variable "allocated_storage" { default = 100 }
+variable "max_allocated_storage" { default = 200 }
 
 variable "publicly_accessible" {
   type    = bool

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -12,7 +12,12 @@ variable "engine_version" {
   type    = string
 }
 variable "allocated_storage" { default = 100 }
-variable "max_allocated_storage" { default = 200 }
+
+variable "max_allocated_storage" {
+  type        = number
+  default     = 0
+  description = "When configured, the upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Must be greater than or equal to allocated_storage or 0 to disable Storage Autoscaling."
+}
 
 variable "publicly_accessible" {
   type    = bool

--- a/stack/app/rds.tf
+++ b/stack/app/rds.tf
@@ -39,6 +39,7 @@ module "rds" {
   instance_class            = var.rds_instance_class
   engine_version            = var.rds_engine_version
   allocated_storage         = var.rds_allocated_storage
+  max_allocated_storage     = var.rds_max_allocated_storage
   multi_az                  = var.rds_multi_az == null ? var.environment == "production" : var.rds_multi_az
   master_db_instance_arn    = var.rds_master_db_instance_arn
   is_read_replica           = var.rds_is_read_replica

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -259,34 +259,47 @@ variable "rds_master_db_vpc_cidr_block" {
   default = null
   type    = string
 }
+
 variable "rds_master_db_region" {
   type    = string
   default = null
 }
+
 variable "rds_master_db_vpc_id" {
   type    = string
   default = null
 }
+
 variable "rds_master_db_kms_key_arn" {
   type    = string
   default = null
 }
+
 variable "rds_master_nat_route_table_ids" {
   type    = list(string)
   default = []
 }
+
 variable "rds_instance_class" {
   type    = string
   default = "db.t3.micro"
 }
+
 variable "rds_engine_version" {
   type    = string
   default = "13"
 }
+
 variable "rds_allocated_storage" {
   type    = number
   default = 100
 }
+
+variable "rds_max_allocated_storage" {
+  type    = number
+  default = 200
+}
+
 variable "rds_allow_from_cidr_blocks" {
   type    = list(string)
   default = []

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -296,8 +296,9 @@ variable "rds_allocated_storage" {
 }
 
 variable "rds_max_allocated_storage" {
-  type    = number
-  default = 200
+  type        = number
+  default     = 0
+  description = "When configured, the upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Must be greater than or equal to allocated_storage or 0 to disable Storage Autoscaling."
 }
 
 variable "rds_allow_from_cidr_blocks" {


### PR DESCRIPTION
#### Summary

Add max_allocated_storage to turn on the storage autoscaling

#### Motivation

Enable the rds to autoscale itself when it reach its full storage
