### PR TITLE
Relax health check requirements

### DIFF
--- a/ecs/target-groups.tf
+++ b/ecs/target-groups.tf
@@ -8,11 +8,11 @@ resource "aws_alb_target_group" "ecs" {
 
   health_check {
     path                = var.health_check_path
-    healthy_threshold   = 2
-    unhealthy_threshold = 3
-    timeout             = 25
-    interval            = 30
-    matcher             = "200,301,302,401,403,404"
+    healthy_threshold   = 2  # The number of consecutive health checks successes required before considering an unhealthy target healthy.
+    unhealthy_threshold = 5  # The number of consecutive health check failures required before considering the target unhealthy. For Network Load Balancers, this value must be the same as the healthy_threshold.
+    timeout             = 30 # The amount of time, in seconds, during which no response means a failed health check. For Application Load Balancers, the range is 2 to 120 seconds.
+    interval            = 60 # The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds.
+    matcher             = "200,204"
   }
 
   tags = {


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

Some apps take longer to boot up. With the current setting, tasks continue to fail because the health check considers them unhealthy before they finished booting.

#### Motivation


