### PR TITLE
Remove duplicated log stream prefix

### DIFF
--- a/ecs-deploy/task-definitions/sidecar.json
+++ b/ecs-deploy/task-definitions/sidecar.json
@@ -19,8 +19,7 @@
       "options": {
           "awslogs-create-group": "true",
           "awslogs-group": "${LOG_GROUP_NAME}",
-          "awslogs-region": "${REGION}",
-          "awslogs-stream-prefix": "${NAME}"
+          "awslogs-region": "${REGION}"
       }
   }
 }

--- a/ecs-deploy/task-definitions/web.json
+++ b/ecs-deploy/task-definitions/web.json
@@ -16,7 +16,6 @@
             "awslogs-create-group": "true",
             "awslogs-group": "/ecs/${PROJECT}-${ENVIRONMENT}",
             "awslogs-region": "${REGION}",
-            "awslogs-stream-prefix": "${NAME}",
             "mode": "${ECS_FARGATE_LOG_MODE}"
         }
     }


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

removes the log stream prefix, since AWS already adds the container name as a prefix, i.e. we had the same prefix twice in the log stream 
name.

#### Motivation

cleaner set  up
