### PR TITLE
[Chore] Add cloudwatch event rule to monitor the stopped container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 This project does not follow SemVer, since modules are independent of each other; thus, SemVer does not make sense. Changes are grouped per module.
 
 ## Unreleased
+### ecs
+- Add cloudwatch event rules to monitor the state changes of container tasks. [#252](https://github.com/dbl-works/terraform/pull/252)
+
 ### HTTP Proxy
 - renamed `ssh_enabled` to `maintenance_mode` to better reflect its purpose
 - `maintenance_mode` now allows outbound traffic from all of the internet to e.g. update and install packages

--- a/ecs/cloudwatch-event-rule.tf
+++ b/ecs/cloudwatch-event-rule.tf
@@ -1,0 +1,48 @@
+locals {
+  cloudwatch_event_rule_name = "${local.project}-${local.environment}-stopped_container"
+}
+
+resource "aws_cloudwatch_event_rule" "stopped_container" {
+  name        = local.cloudwatch_event_rule_name
+  description = "Capture stopped ECS container"
+
+  event_pattern = jsonencode({
+    source = ["aws.ecs"],
+    # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_cwet2.html
+    detail = {
+      "clusterArn" = [aws_ecs_cluster.main.arn],
+      "group"      = var.cluster_service_group,
+      "lastStatus" = [
+        "STOPPED"
+      ],
+    }
+    detail-type = [
+      "ECS Task State Change"
+    ]
+  })
+
+  tags = {
+    Project     = var.project
+    Environment = var.environment
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.stopped_container
+  ]
+}
+
+resource "aws_cloudwatch_event_target" "stopped_container" {
+  rule      = aws_cloudwatch_event_rule.stopped_container.name
+  target_id = local.cloudwatch_event_rule_name
+  arn       = aws_cloudwatch_log_group.stopped_container.arn
+}
+
+resource "aws_cloudwatch_log_group" "stopped_container" {
+  name              = "/aws/events/${local.cloudwatch_event_rule_name}"
+  retention_in_days = 14
+
+  tags = {
+    Project     = var.project
+    Environment = var.environment
+  }
+}

--- a/ecs/cloudwatch-event-rule.tf
+++ b/ecs/cloudwatch-event-rule.tf
@@ -1,5 +1,5 @@
 locals {
-  cloudwatch_event_rule_name = "${local.project}-${local.environment}-stopped_container"
+  cloudwatch_event_rule_name = "${var.project}-${var.environment}-stopped_container"
 }
 
 resource "aws_cloudwatch_event_rule" "stopped_container" {

--- a/ecs/cloudwatch-event-rule.tf
+++ b/ecs/cloudwatch-event-rule.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_event_rule" "stopped_container" {
     # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_cwet2.html
     detail = {
       "clusterArn" = [aws_ecs_cluster.main.arn],
-      "group"      = var.cluster_service_group,
+      "group"      = var.monitored_service_groups,
       "lastStatus" = [
         "STOPPED"
       ],

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -181,7 +181,7 @@ variable "service_discovery_enabled" {
   default = true
 }
 
-variable "cluster_service_group" {
+variable "monitored_service_groups" {
   type        = list(string)
   default     = ["service:web"]
   description = "ECS service groups that we would like to monitor when a container reaches a STOPPED state."

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -184,7 +184,7 @@ variable "service_discovery_enabled" {
 variable "monitored_service_groups" {
   type        = list(string)
   default     = ["service:web"]
-  description = "ECS service groups that we would like to monitor when a container reaches a STOPPED state."
+  description = "ECS service groups to monitor STOPPED containers."
 }
 
 variable "health_check_options" {

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -186,7 +186,7 @@ variable "monitored_service_groups" {
   default     = ["service:web"]
   description = "ECS service groups that we would like to monitor when a container reaches a STOPPED state."
 }
-  
+
 variable "health_check_options" {
   type = object({
     healthy_threshold   = optional(number, 2)  # The number of consecutive health checks successes required before considering an unhealthy target healthy.

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -180,3 +180,9 @@ variable "service_discovery_enabled" {
   type    = bool
   default = true
 }
+
+variable "cluster_service_group" {
+  type        = list(string)
+  default     = ["service:web"]
+  description = "ECS service groups that we would like to monitor when a container reaches a STOPPED state."
+}

--- a/stack/app/ecs.tf
+++ b/stack/app/ecs.tf
@@ -29,6 +29,7 @@ module "ecs" {
   name                        = var.ecs_name # custom name when convention exceeds 32 chars
   region                      = var.region   # used for e.g CloudWatch metrics
   keep_alive_timeout          = var.keep_alive_timeout
+  monitored_service_groups    = var.monitored_service_groups
 
   allow_internal_traffic_to_ports = var.allow_internal_traffic_to_ports
   allow_alb_traffic_to_ports      = var.allow_alb_traffic_to_ports

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -326,6 +326,12 @@ variable "allow_internal_traffic_to_ports" {
   default = []
 }
 
+variable "monitored_service_groups" {
+  type        = list(string)
+  default     = ["service:web"]
+  description = "ECS service groups that we would like to monitor when a container reaches a STOPPED state."
+}
+
 variable "keep_alive_timeout" {
   type    = number
   default = 60

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -341,7 +341,7 @@ variable "allow_internal_traffic_to_ports" {
 variable "monitored_service_groups" {
   type        = list(string)
   default     = ["service:web"]
-  description = "ECS service groups that we would like to monitor when a container reaches a STOPPED state."
+  description = "ECS service groups to monitor STOPPED containers."
 }
 
 variable "keep_alive_timeout" {


### PR DESCRIPTION
#### Summary
Add cloudwatch event rule to monitor the container stopped reason

#### Motivation
When the container stopped abruptly, the logs will disappear after a while
