### PR TITLE
Revert "Remove duplicated log stream prefix"

### DIFF
--- a/ecs-deploy/task-definitions/sidecar.json
+++ b/ecs-deploy/task-definitions/sidecar.json
@@ -19,7 +19,8 @@
       "options": {
           "awslogs-create-group": "true",
           "awslogs-group": "${LOG_GROUP_NAME}",
-          "awslogs-region": "${REGION}"
+          "awslogs-region": "${REGION}",
+          "awslogs-stream-prefix": "${NAME}"
       }
   }
 }

--- a/ecs-deploy/task-definitions/web.json
+++ b/ecs-deploy/task-definitions/web.json
@@ -16,6 +16,7 @@
             "awslogs-create-group": "true",
             "awslogs-group": "/ecs/${PROJECT}-${ENVIRONMENT}",
             "awslogs-region": "${REGION}",
+            "awslogs-stream-prefix": "${NAME}",
             "mode": "${ECS_FARGATE_LOG_MODE}"
         }
     }


### PR DESCRIPTION
Reverts dbl-works/terraform#251


```
│ Error: creating ECS Task Definition (***): ClientException: Fargate requires log configuration options to include awslogs-stream-prefix to support log driver awslogs.
│ 
│   with module.ecs_service_***.aws_ecs_task_definition.main,
│   on .terraform/modules/ecs_service_***/ecs-deploy/ecs_task_definition.tf line 1, in resource "aws_ecs_task_definition" "main":
│    1: resource "aws_ecs_task_definition" "main" {
```