### PR TITLE
rds: add log_min_duration_statement, log_retention_period variables, log_min_error_statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ This project does not follow SemVer, since modules are independent of each other
 
 ## Unreleased
 ### rds
-- Add log_min_duration_statement and log_retention_period variables
+- Add log_min_duration_statement, log_retention_period variables, log_min_error_statement. [#263](https://github.com/dbl-works/terraform/pull/263)
 
 ### stack/app
-- Add rds_log_min_duration_statement and rds_log_retention_period variables
+- Add rds_log_min_duration_statement, rds_log_retention_period variables, rds_log_min_error_statement. [#263](https://github.com/dbl-works/terraform/pull/263)
 
 ### Secrets
 * Passing in a `kms_key_id` is now optional. If omitted, a new key is created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 This project does not follow SemVer, since modules are independent of each other; thus, SemVer does not make sense. Changes are grouped per module.
 
 ## Unreleased
+### rds
+- Add log_min_duration_statement and log_retention_period variables
+
+### stack/app
+- Add rds_log_min_duration_statement and rds_log_retention_period variables
+
 ### Secrets
 * Passing in a `kms_key_id` is now optional. If omitted, a new key is created
 

--- a/rds/parameter-group.tf
+++ b/rds/parameter-group.tf
@@ -20,6 +20,11 @@ resource "aws_db_parameter_group" "current" {
   }
 
   parameter {
+    name  = "log_min_error_statement"
+    value = var.log_min_error_statement
+  }
+
+  parameter {
     name  = "rds.force_ssl"
     value = 1
   }

--- a/rds/parameter-group.tf
+++ b/rds/parameter-group.tf
@@ -8,13 +8,15 @@ resource "aws_db_parameter_group" "current" {
     name  = "log_statement"
     value = "none" # Logs nothing
   }
+
   parameter {
     name  = "log_min_duration_statement"
-    value = "0"
+    value = var.log_min_duration_statement
   }
+
   parameter {
     name  = "rds.log_retention_period"
-    value = 4320 # in minutes, must be between 1440-10080 (1-7 days)
+    value = var.log_retention_period
   }
 
   parameter {
@@ -27,6 +29,7 @@ resource "aws_db_parameter_group" "current" {
     value        = var.enable_replication ? 1 : 0
     apply_method = "pending-reboot"
   }
+
   parameter {
     name         = "wal_sender_timeout"
     value        = var.enable_replication ? 0 : 60000 # default, 1 min

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -112,3 +112,15 @@ variable "identifier" {
 locals {
   name = var.name != null ? var.name : "${var.project}-${var.environment}${var.regional ? "-${var.region}" : ""}"
 }
+
+variable "log_min_duration_statement" {
+  type        = number
+  default     = 3000
+  description = "Used to log SQL statements that run longer than a specified duration of time (in ms)."
+}
+
+variable "log_retention_period" {
+  type        = number
+  default     = 4320
+  description = "Controls how long automatic RDS log files are retained before being deleted (in min, must be between 1440-10080 (1-7 days)."
+}

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -115,12 +115,29 @@ locals {
 
 variable "log_min_duration_statement" {
   type        = number
-  default     = 3000
+  default     = -1
   description = "Used to log SQL statements that run longer than a specified duration of time (in ms)."
 }
 
 variable "log_retention_period" {
   type        = number
-  default     = 4320
+  default     = 1440
   description = "Controls how long automatic RDS log files are retained before being deleted (in min, must be between 1440-10080 (1-7 days)."
+
+  validation {
+    condition     = var.log_retention_period >= 1440 && var.log_retention_period <= 10080
+    error_message = "Log retention period must be between 1440-10080 (1-7 days)."
+  }
+}
+
+variable "log_min_error_statement" {
+  type        = string
+  default     = "panic"
+  description = "Controls which SQL statements that cause an error condition are recorded in the server log."
+
+
+  validation {
+    condition     = contains(["debug5", "debug4", "debug3", "debug2", "debug1", "info", "notice", "warning", "error", "log", "fatal", "panic"], var.log_min_error_statement)
+    error_message = "The valid values are [debug5, debug4, debug3, debug2, debug1, info, notice, warning, error, log, fatal, panic]"
+  }
 }

--- a/stack/app/rds.tf
+++ b/stack/app/rds.tf
@@ -35,19 +35,21 @@ module "rds" {
   ]
 
   # optional
-  username                  = var.rds_is_read_replica ? null : local.credentials.db_username
-  instance_class            = var.rds_instance_class
-  engine_version            = var.rds_engine_version
-  allocated_storage         = var.rds_allocated_storage
-  multi_az                  = var.rds_multi_az == null ? var.environment == "production" : var.rds_multi_az
-  master_db_instance_arn    = var.rds_master_db_instance_arn
-  is_read_replica           = var.rds_is_read_replica
-  regional                  = var.regional
-  name                      = var.rds_name
-  identifier                = var.rds_identifier
-  allow_from_cidr_blocks    = var.rds_allow_from_cidr_blocks
-  subnet_group_name         = var.rds_subnet_group_name
-  delete_automated_backups  = var.rds_delete_automated_backups
-  skip_final_snapshot       = var.rds_skip_final_snapshot
-  final_snapshot_identifier = var.rds_final_snapshot_identifier
+  username                   = var.rds_is_read_replica ? null : local.credentials.db_username
+  instance_class             = var.rds_instance_class
+  engine_version             = var.rds_engine_version
+  allocated_storage          = var.rds_allocated_storage
+  multi_az                   = var.rds_multi_az == null ? var.environment == "production" : var.rds_multi_az
+  master_db_instance_arn     = var.rds_master_db_instance_arn
+  is_read_replica            = var.rds_is_read_replica
+  regional                   = var.regional
+  name                       = var.rds_name
+  identifier                 = var.rds_identifier
+  allow_from_cidr_blocks     = var.rds_allow_from_cidr_blocks
+  subnet_group_name          = var.rds_subnet_group_name
+  delete_automated_backups   = var.rds_delete_automated_backups
+  skip_final_snapshot        = var.rds_skip_final_snapshot
+  final_snapshot_identifier  = var.rds_final_snapshot_identifier
+  log_min_duration_statement = var.rds_log_min_duration_statement
+  log_retention_period       = var.rds_log_retention_period
 }

--- a/stack/app/rds.tf
+++ b/stack/app/rds.tf
@@ -52,4 +52,5 @@ module "rds" {
   final_snapshot_identifier  = var.rds_final_snapshot_identifier
   log_min_duration_statement = var.rds_log_min_duration_statement
   log_retention_period       = var.rds_log_retention_period
+  log_min_error_statement    = var.rds_log_min_error_statement
 }

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -330,7 +330,7 @@ variable "rds_log_retention_period" {
   description = "Controls how long automatic RDS log files are retained before being deleted (in min, must be between 1440-10080 (1-7 days)."
 
   validation {
-    condition     = var.log_retention_period >= 1440 && var.log_retention_period <= 10080
+    condition     = var.rds_log_retention_period >= 1440 && var.rds_log_retention_period <= 10080
     error_message = "Log retention period must be between 1440-10080 (1-7 days)."
   }
 }
@@ -342,7 +342,7 @@ variable "rds_log_min_error_statement" {
 
 
   validation {
-    condition     = contains(["debug5", "debug4", "debug3", "debug2", "debug1", "info", "notice", "warning", "error", "log", "fatal", "panic"], var.log_min_error_statement)
+    condition     = contains(["debug5", "debug4", "debug3", "debug2", "debug1", "info", "notice", "warning", "error", "log", "fatal", "panic"], var.rds_log_min_error_statement)
     error_message = "The valid values are [debug5, debug4, debug3, debug2, debug1, info, notice, warning, error, log, fatal, panic]"
   }
 }

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -320,14 +320,31 @@ variable "rds_final_snapshot_identifier" {
 
 variable "rds_log_min_duration_statement" {
   type        = number
-  default     = 3000
+  default     = -1
   description = "Used to log SQL statements that run longer than a specified duration of time (in ms)."
 }
 
 variable "rds_log_retention_period" {
   type        = number
-  default     = 4320
+  default     = 1440
   description = "Controls how long automatic RDS log files are retained before being deleted (in min, must be between 1440-10080 (1-7 days)."
+
+  validation {
+    condition     = var.log_retention_period >= 1440 && var.log_retention_period <= 10080
+    error_message = "Log retention period must be between 1440-10080 (1-7 days)."
+  }
+}
+
+variable "rds_log_min_error_statement" {
+  type        = string
+  default     = "panic"
+  description = "Controls which SQL statements that cause an error condition are recorded in the server log."
+
+
+  validation {
+    condition     = contains(["debug5", "debug4", "debug3", "debug2", "debug1", "info", "notice", "warning", "error", "log", "fatal", "panic"], var.log_min_error_statement)
+    error_message = "The valid values are [debug5, debug4, debug3, debug2, debug1, info, notice, warning, error, log, fatal, panic]"
+  }
 }
 # =============== RDS ================ #
 

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -317,6 +317,18 @@ variable "rds_final_snapshot_identifier" {
   type    = string
   default = null
 }
+
+variable "rds_log_min_duration_statement" {
+  type        = number
+  default     = 3000
+  description = "Used to log SQL statements that run longer than a specified duration of time (in ms)."
+}
+
+variable "rds_log_retention_period" {
+  type        = number
+  default     = 4320
+  description = "Controls how long automatic RDS log files are retained before being deleted (in min, must be between 1440-10080 (1-7 days)."
+}
 # =============== RDS ================ #
 
 # =============== ECS ================ #


### PR DESCRIPTION
#### Summary

log_min_duration_statement determine the statement which exceeds x second to be logged.
If we set it to zero, it means that we will log every statement to the logs.
This will be useful for testing and debugging purpose but not good for the performances as writing logs require disk I/O. 
If a large number of queries are being executed, the constant logging can lead to significant I/O operations, competing with the actual database read/write operations, especially if the logs and database data are on the same disk.

