### PR TITLE
rds: add ca_cert_identifier as var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 This project does not follow SemVer, since modules are independent of each other; thus, SemVer does not make sense. Changes are grouped per module.
 
 ## Unreleased
+### rds
+- Add ca_cert_identifier.[#269](https://github.com/dbl-works/terraform/pull/269)
+
+### stack/app
+- Add rds_ca_cert_identifier.[#269](https://github.com/dbl-works/terraform/pull/269)
 
 ## [v2023.10.15]
 ### rds

--- a/rds/rds.tf
+++ b/rds/rds.tf
@@ -36,6 +36,7 @@ resource "aws_db_instance" "main" {
   delete_automated_backups        = var.delete_automated_backups
   skip_final_snapshot             = var.skip_final_snapshot
   final_snapshot_identifier       = var.is_read_replica ? null : (var.final_snapshot_identifier == null ? local.final_snapshot_identifier : var.final_snapshot_identifier)
+  ca_cert_identifier              = var.ca_cert_identifier
 
   enabled_cloudwatch_logs_exports = [
     "postgresql",

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -6,6 +6,11 @@ variable "kms_key_arn" {}
 variable "project" {}
 variable "environment" {}
 
+variable "ca_cert_identifier" {
+  default = "rds-ca-rsa2048-g1"
+  type    = string
+}
+
 variable "instance_class" { default = "db.t3.micro" }
 variable "engine_version" {
   default = "14"

--- a/stack/app/rds.tf
+++ b/stack/app/rds.tf
@@ -53,4 +53,5 @@ module "rds" {
   log_min_duration_statement = var.rds_log_min_duration_statement
   log_retention_period       = var.rds_log_retention_period
   log_min_error_statement    = var.rds_log_min_error_statement
+  ca_cert_identifier         = var.rds_ca_cert_identifier
 }

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -340,11 +340,16 @@ variable "rds_log_min_error_statement" {
   default     = "panic"
   description = "Controls which SQL statements that cause an error condition are recorded in the server log."
 
-
   validation {
     condition     = contains(["debug5", "debug4", "debug3", "debug2", "debug1", "info", "notice", "warning", "error", "log", "fatal", "panic"], var.rds_log_min_error_statement)
     error_message = "The valid values are [debug5, debug4, debug3, debug2, debug1, info, notice, warning, error, log, fatal, panic]"
   }
+}
+
+variable "rds_ca_cert_identifier" {
+  default     = "rds-ca-rsa2048-g1"
+  type        = string
+  description = "The identifier of the CA certificate for the DB instance."
 }
 # =============== RDS ================ #
 


### PR DESCRIPTION
#### Summary
**Current:**
> When you create a new DB instance, the default CA is still rds-ca-2019 until January 25, 2024, when it will be changed to rds-ca-rsa2048-g1

The default CA is going to expired in 2024. Refer to [here](https://aws.amazon.com/blogs/aws/rotate-your-ssl-tls-certificates-now-amazon-rds-and-amazon-aurora-expire-in-2024/)
**Expectations:**
- Set ca_cert_identifier to `rds-ca-rsa2048-g1`

#### Motivation
https://github.com/dbl-works/terraform/issues/266
