### PR TITLE
Update PostgreSQL default version from 14 to 16

### DIFF
--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -20,11 +20,16 @@ variable "backup_retention_period" {
   type    = number
 }
 
-variable "instance_class" { default = "db.t3.micro" }
-variable "engine_version" {
-  default = "14"
+variable "instance_class" {
+  default = "db.t3.micro"
   type    = string
 }
+
+variable "engine_version" {
+  default = "16"
+  type    = string
+}
+
 variable "allocated_storage" {
   type    = number
   default = 10


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

Bump PostgreSQL default version from 14 to 16. Works on CircleCI & AWS.

Tested with a few projects using our standard stack ✅ 

#### Motivation

<!-- Why are you making this change? -->
