### PR TITLE
stack/app: set default rds_engine_version to 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 This project does not follow SemVer, since modules are independent of each other; thus, SemVer does not make sense. Changes are grouped per module.
 
 ## Unreleased
+### stack/app
+- Set default rds_engine_version to 16.
+
 ### ecs-deploy/service
 - Add vpc_name variables. [#287](https://github.com/dbl-works/terraform/pull/287)
 

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -283,7 +283,7 @@ variable "rds_instance_class" {
 }
 variable "rds_engine_version" {
   type    = string
-  default = "13"
+  default = "16"
 }
 variable "rds_allocated_storage" {
   type    = number


### PR DESCRIPTION
#### Summary

Set rds_engine_version default value to 16

