### PR TITLE
rds: set nullable to false for engine_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 This project does not follow SemVer, since modules are independent of each other; thus, SemVer does not make sense. Changes are grouped per module.
 
 ## Unreleased
+### rds
+- Set nullable to false for engine_version. [#292](https://github.com/dbl-works/terraform/pull/292)
+
 ### circleci-token-rotator
 - New module to rotate IAM user's AWS Access Keys on CircleCI. [#278](https://github.com/dbl-works/terraform/pull/278)
 

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -26,8 +26,9 @@ variable "instance_class" {
 }
 
 variable "engine_version" {
-  default = "16"
-  type    = string
+  default  = "16"
+  type     = string
+  nullable = false
 }
 
 variable "allocated_storage" {

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -283,7 +283,7 @@ variable "rds_instance_class" {
 }
 variable "rds_engine_version" {
   type    = string
-  default = "16"
+  default = null
 }
 variable "rds_allocated_storage" {
   type    = number


### PR DESCRIPTION
#### Summary

- Set nullable to false for engine_version in rds module

#### Motivation

- We don't need to manage default value in both module
