### PR TITLE
iam/iam-for-deploy-bot: add ecs:TagResource permission to deploybot

### DIFF
--- a/iam/iam-for-deploy-bot/main.tf
+++ b/iam/iam-for-deploy-bot/main.tf
@@ -131,6 +131,7 @@ resource "aws_iam_policy" "deploy-bot-extra-access" {
           "ecs:ListServices",
           "ecs:ListTasks",
           "ecs:DescribeTaskDefinition",
+          "ecs:TagResource",
           "elasticloadbalancing:Describe*",
           "iam:GetRole",
           "logs:*",


### PR DESCRIPTION
#### Summary

Add extra permission to deploybot.

AWS require the explicit permission to tag ecs resources

```
To ensure your IAM principals continue applying tags to newly created ECS resources on or after March 29, 2024, we strongly recommend adding the following statement(s) to your IAM policies:

Allow Tagging during creation for all ECS Resources

Adding the ecs:TagResource Action as described as follows would Allow tagging during ECS resource creation [2].
```
