### PR TITLE
slack/chatbot: update chatbot policy so user can access dashboard info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 This project does not follow SemVer, since modules are independent of each other; thus, SemVer does not make sense. Changes are grouped per module.
 
 ## Unreleased
+### slack/chatbot
+- Grant more permissions to chatbot channel role. [#299](https://github.com/dbl-works/terraform/pull/299)
 
 ## [v2024.01.25]
 ### slack/ecr-scanner-notifier

--- a/slack/chatbot/main.tf
+++ b/slack/chatbot/main.tf
@@ -17,7 +17,7 @@ resource "aws_iam_role" "chatbot" {
       {
         "Effect" : "Allow",
         "Principal" : {
-          "Service" : "management.chatbot.amazonaws.com"
+          "Service" : "chatbot.amazonaws.com"
         },
         "Action" : "sts:AssumeRole"
       }
@@ -43,6 +43,14 @@ resource "aws_iam_policy" "chatbot_policy" {
           "SNS:Unsubscribe",
           "SNS:Subscribe",
           "SNS:ListSubscriptions"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "*"
+      },
+      {
+        "Action" : [
+          "cloudwatch:List*",
+          "cloudwatch:Get*"
         ],
         "Effect" : "Allow",
         "Resource" : "*"


### PR DESCRIPTION
#### Summary
Grant more permissions/rights to chatbot channel role

#### Motivation
When user clicks on `List Dashboard`, channel role does not have enough policy to perform the action and grab the metrics.

