### PR TITLE
Upgrade Fivetran Terraform provider from 0.1 to 1.0, allow configuring Fivetran-Lambda Sync

### DIFF
--- a/cloudwatch-snowflake/README.md
+++ b/cloudwatch-snowflake/README.md
@@ -18,7 +18,7 @@ terraform {
     }
     fivetran = {
       source  = "fivetran/fivetran"
-      version = "~> 0.6.1"
+      version = "~> 1.0"
     }
   }
 

--- a/cloudwatch-snowflake/fivetran.tf
+++ b/cloudwatch-snowflake/fivetran.tf
@@ -17,11 +17,8 @@ resource "fivetran_connector" "lambda" {
 resource "fivetran_connector_schedule" "lambda" {
   connector_id = fivetran_connector.lambda.id
 
-  sync_frequency  = "60"
-  daily_sync_time = "03:00"
-
+  sync_frequency    = "60"
   paused            = false
   pause_after_trial = false
-
-  schedule_type = "auto"
+  schedule_type     = "auto"
 }

--- a/cloudwatch-snowflake/fivetran.tf
+++ b/cloudwatch-snowflake/fivetran.tf
@@ -1,10 +1,7 @@
 resource "fivetran_connector" "lambda" {
-  group_id          = var.fivetran_group_id
-  service           = "aws_lambda"
-  sync_frequency    = 60 // min
-  paused            = false
-  pause_after_trial = false
-  run_setup_tests   = true
+  group_id        = var.fivetran_group_id
+  service         = "aws_lambda"
+  run_setup_tests = true
 
   destination_schema {
     name = "cloudwatch_metrics_${var.organisation}_${replace(var.aws_region_code, "/-/", "_")}"
@@ -15,4 +12,16 @@ resource "fivetran_connector" "lambda" {
     role_arn = var.lambda_role_arn == null ? aws_iam_role.lambda[0].arn : var.lambda_role_arn
     region   = var.aws_region_code
   }
+}
+
+resource "fivetran_connector_schedule" "lambda" {
+  connector_id = fivetran_connector.lambda.id
+
+  sync_frequency  = "60"
+  daily_sync_time = "03:00"
+
+  paused            = false
+  pause_after_trial = false
+
+  schedule_type = "auto"
 }

--- a/cloudwatch-snowflake/versions.tf
+++ b/cloudwatch-snowflake/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     fivetran = {
       source  = "fivetran/fivetran"
-      version = "~> 0.6.1"
+      version = "~> 1.0"
     }
   }
 

--- a/fivetran/README.md
+++ b/fivetran/README.md
@@ -124,7 +124,7 @@ terraform {
   required_providers {
     fivetran = {
       source  = "fivetran/fivetran"
-      version = "~> 0.6.1"
+      version = "~> 1.0"
     }
   }
 }

--- a/fivetran/connectors.tf
+++ b/fivetran/connectors.tf
@@ -2,11 +2,8 @@
 resource "fivetran_connector" "rds" {
   for_each = { for rds in var.sources_rds : rds.host => rds }
 
-  group_id          = fivetran_destination.main.group_id
-  service           = "postgres_rds" # https://fivetran.com/docs/rest-api/connectors/config#postgres
-  sync_frequency    = 60             # mins, supported values: 5, 15, 30, 60, 120, 180, 360, 480, 720, 1440.
-  paused            = false
-  pause_after_trial = false
+  group_id = fivetran_destination.main.group_id
+  service  = "postgres_rds" # https://fivetran.com/docs/rest-api/connectors/config#postgres
 
   destination_schema {
     name = "aws_rds_${each.value.database}" # name shown on Fivetran UI
@@ -29,15 +26,25 @@ resource "fivetran_connector" "rds" {
   }
 }
 
+resource "fivetran_connector_schedule" "rds" {
+  connector_id = fivetran_connector.rds.id
+
+  sync_frequency  = "60"
+  daily_sync_time = "03:00"
+
+  paused            = false
+  pause_after_trial = false
+
+  schedule_type = "auto"
+}
+
+
 resource "fivetran_connector" "github" {
   for_each = { for github in var.sources_github : github.organisation => github }
 
-  group_id          = fivetran_group.group.id
-  service           = "github"
-  sync_frequency    = 60
-  paused            = false
-  pause_after_trial = false
-  run_setup_tests   = true
+  group_id        = fivetran_group.group.id
+  service         = "github"
+  run_setup_tests = true
 
   destination_schema {
     name = "github_${replace(each.value.organisation, "/[^0-9A-Za-z_]/", "_")}" # name shown on Fivetran UI
@@ -51,6 +58,18 @@ resource "fivetran_connector" "github" {
     username     = each.value.username
     pat          = each.value.pat
   }
+}
+
+resource "fivetran_connector_schedule" "github" {
+  connector_id = fivetran_connector.github.id
+
+  sync_frequency  = "60"
+  daily_sync_time = "03:00"
+
+  paused            = false
+  pause_after_trial = false
+
+  schedule_type = "auto"
 }
 
 module "lambda_connector" {

--- a/fivetran/connectors.tf
+++ b/fivetran/connectors.tf
@@ -27,7 +27,9 @@ resource "fivetran_connector" "rds" {
 }
 
 resource "fivetran_connector_schedule" "rds" {
-  connector_id = fivetran_connector.rds.id
+  for_each = { for rds_connector in fivetran_connector.rds : rds_connector.id => rds_connector }
+
+  connector_id = each.key
 
   sync_frequency  = "60"
   daily_sync_time = "03:00"
@@ -61,7 +63,9 @@ resource "fivetran_connector" "github" {
 }
 
 resource "fivetran_connector_schedule" "github" {
-  connector_id = fivetran_connector.github.id
+  for_each = { for rds_connector in fivetran_connector.rds : rds_connector.id => rds_connector }
+
+  connector_id = each.key
 
   sync_frequency  = "60"
   daily_sync_time = "03:00"

--- a/fivetran/connectors.tf
+++ b/fivetran/connectors.tf
@@ -63,7 +63,7 @@ resource "fivetran_connector" "github" {
 }
 
 resource "fivetran_connector_schedule" "github" {
-  for_each = { for rds_connector in fivetran_connector.rds : rds_connector.id => rds_connector }
+  for_each = { for github_connector in fivetran_connector.github : github_connector.id => github_connector }
 
   connector_id = each.key
 

--- a/fivetran/connectors.tf
+++ b/fivetran/connectors.tf
@@ -31,13 +31,10 @@ resource "fivetran_connector_schedule" "rds" {
 
   connector_id = each.key
 
-  sync_frequency  = "60"
-  daily_sync_time = "03:00"
-
+  sync_frequency    = "60"
   paused            = false
   pause_after_trial = false
-
-  schedule_type = "auto"
+  schedule_type     = "auto"
 }
 
 
@@ -67,13 +64,10 @@ resource "fivetran_connector_schedule" "github" {
 
   connector_id = each.key
 
-  sync_frequency  = "60"
-  daily_sync_time = "03:00"
-
+  sync_frequency    = "60"
   paused            = false
   pause_after_trial = false
-
-  schedule_type = "auto"
+  schedule_type     = "auto"
 }
 
 module "lambda_connector" {

--- a/fivetran/connectors/google_analytics/README.md
+++ b/fivetran/connectors/google_analytics/README.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     fivetran = {
       source  = "fivetran/fivetran"
-      version = "~> 0.6.1"
+      version = "~> 1.0"
     }
   }
 

--- a/fivetran/connectors/google_analytics/fivetran.tf
+++ b/fivetran/connectors/google_analytics/fivetran.tf
@@ -4,12 +4,9 @@ locals {
 }
 
 resource "fivetran_connector" "google_analytics" {
-  group_id          = var.fivetran_group_id
-  service           = "google_analytics"
-  sync_frequency    = var.sync_frequency // min
-  paused            = false
-  pause_after_trial = false
-  run_setup_tests   = true
+  group_id        = var.fivetran_group_id
+  service         = "google_analytics"
+  run_setup_tests = true
 
   destination_schema {
     name = local.name
@@ -43,4 +40,16 @@ resource "fivetran_connector" "google_analytics" {
       refresh_token = auth.value.refresh_token
     }
   }
+}
+
+resource "fivetran_connector_schedule" "lambda" {
+  connector_id = fivetran_connector.lambda.id
+
+  sync_frequency  = var.sync_frequency
+  daily_sync_time = "03:00"
+
+  paused            = false
+  pause_after_trial = false
+
+  schedule_type = "auto"
 }

--- a/fivetran/connectors/google_analytics/fivetran.tf
+++ b/fivetran/connectors/google_analytics/fivetran.tf
@@ -42,8 +42,8 @@ resource "fivetran_connector" "google_analytics" {
   }
 }
 
-resource "fivetran_connector_schedule" "lambda" {
-  connector_id = fivetran_connector.lambda.id
+resource "fivetran_connector_schedule" "google_analytics" {
+  connector_id = fivetran_connector.google_analytics.id
 
   sync_frequency  = var.sync_frequency
   daily_sync_time = "03:00"

--- a/fivetran/connectors/google_analytics/fivetran.tf
+++ b/fivetran/connectors/google_analytics/fivetran.tf
@@ -45,11 +45,8 @@ resource "fivetran_connector" "google_analytics" {
 resource "fivetran_connector_schedule" "google_analytics" {
   connector_id = fivetran_connector.google_analytics.id
 
-  sync_frequency  = var.sync_frequency
-  daily_sync_time = "03:00"
-
+  sync_frequency    = var.sync_frequency
   paused            = false
   pause_after_trial = false
-
-  schedule_type = "auto"
+  schedule_type     = "auto"
 }

--- a/fivetran/connectors/google_analytics/versions.tf
+++ b/fivetran/connectors/google_analytics/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     fivetran = {
       source  = "fivetran/fivetran"
-      version = "~> 0.6.1"
+      version = "~> 1.0"
     }
   }
 

--- a/fivetran/connectors/lambda/README.md
+++ b/fivetran/connectors/lambda/README.md
@@ -12,7 +12,7 @@ terraform {
     }
     fivetran = {
       source  = "fivetran/fivetran"
-      version = "~> 0.6.1"
+      version = "~> 1.0"
     }
   }
 

--- a/fivetran/connectors/lambda/examples/cloudwatch_lambda/versions.tf
+++ b/fivetran/connectors/lambda/examples/cloudwatch_lambda/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     fivetran = {
       source  = "fivetran/fivetran"
-      version = "~> 0.6.1"
+      version = "~> 1.0"
     }
   }
 

--- a/fivetran/connectors/lambda/fivetran.tf
+++ b/fivetran/connectors/lambda/fivetran.tf
@@ -1,10 +1,7 @@
 resource "fivetran_connector" "lambda" {
-  group_id          = var.fivetran_group_id
-  service           = "aws_lambda"
-  sync_frequency    = var.sync_frequency // min
-  paused            = false
-  pause_after_trial = false
-  run_setup_tests   = true
+  group_id        = var.fivetran_group_id
+  service         = "aws_lambda"
+  run_setup_tests = true
 
   destination_schema {
     name = var.connector_name == null ? local.function_name : var.connector_name
@@ -15,4 +12,17 @@ resource "fivetran_connector" "lambda" {
     role_arn = var.lambda_role_arn
     region   = var.aws_region_code
   }
+}
+
+
+resource "fivetran_connector_schedule" "lambda" {
+  connector_id = fivetran_connector.lambda.id
+
+  sync_frequency  = var.sync_frequency
+  daily_sync_time = "03:00"
+
+  paused            = false
+  pause_after_trial = false
+
+  schedule_type = "auto"
 }

--- a/fivetran/connectors/lambda/fivetran.tf
+++ b/fivetran/connectors/lambda/fivetran.tf
@@ -18,11 +18,8 @@ resource "fivetran_connector" "lambda" {
 resource "fivetran_connector_schedule" "lambda" {
   connector_id = fivetran_connector.lambda.id
 
-  sync_frequency  = var.sync_frequency
-  daily_sync_time = "03:00"
-
+  sync_frequency    = var.sync_frequency
   paused            = false
   pause_after_trial = false
-
-  schedule_type = "auto"
+  schedule_type     = "auto"
 }

--- a/fivetran/connectors/lambda/main.tf
+++ b/fivetran/connectors/lambda/main.tf
@@ -17,9 +17,9 @@ resource "aws_lambda_function" "main" {
   # Used to trigger updates
   source_code_hash = data.archive_file.zip.output_base64sha256
   handler          = "index.handler"
-  # List of available runtimes: https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
-  runtime = "nodejs16.x"
-  timeout = 300
+  runtime          = var.runtime
+  timeout          = var.timeout
+  memory_size      = var.memory_size
 
   environment {
     variables = var.script_env

--- a/fivetran/connectors/lambda/variables.tf
+++ b/fivetran/connectors/lambda/variables.tf
@@ -8,6 +8,23 @@ variable "lambda_name" {
   default = null
 }
 
+variable "runtime" {
+  type        = string
+  description = "The runtime environment for the Lambda function, see https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime."
+  default     = "nodejs20.x"
+}
+
+variable "timeout" {
+  type    = number
+  default = 900
+}
+
+variable "memory_size" {
+  type        = number
+  description = "The amount of memory that your function has access to."
+  default     = 128
+}
+
 variable "lambda_source_dir" {
   type        = string
   description = "Path to the directory containing the lambda function code"
@@ -63,7 +80,11 @@ variable "script_env" {
 }
 
 variable "sync_frequency" {
-  type        = number
-  default     = 60 // min
-  description = "The supported values are: 5, 15, 30, 60, 120, 180, 360, 480, 720, 1440."
+  type        = string
+  default     = "60" // min
+  description = "The supported values are: 1, 5, 15, 30, 60, 120, 180, 360, 480, 720, 1440."
+  validation {
+    condition     = can(regex("^(1|5|15|30|60|120|180|360|480|720|1440)$", var.sync_frequency))
+    error_message = "The supported values are: 1, 5, 15, 30, 60, 120, 180, 360, 480, 720, 1440."
+  }
 }

--- a/fivetran/connectors/lambda/versions.tf
+++ b/fivetran/connectors/lambda/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     fivetran = {
       source  = "fivetran/fivetran"
-      version = "~> 0.6.1"
+      version = "~> 1.0"
     }
   }
 

--- a/fivetran/versions.tf
+++ b/fivetran/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     fivetran = {
       source  = "fivetran/fivetran"
-      version = "~> 0.6.1"
+      version = "~> 1.0"
     }
   }
 

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -23,10 +23,9 @@ variable "function_name" {
   description = "A unique identifier for the function."
 }
 
-# https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
 variable "runtime" {
   type        = string
-  description = "The runtime environment for the Lambda function."
+  description = "The runtime environment for the Lambda function, see https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime."
   default     = "nodejs20.x"
 }
 


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

Breaking changes of the Fivetran connector for version 0.1 -> 1.0: https://github.com/fivetran/terraform-provider-fivetran/blob/main/CHANGELOG.md#breaking-changes

#### Motivation

We need to allow configuring the Lambda that connects to Fivetran to allow adjusting memory & timeout.
