### PR TITLE
Disable Container Insights by default

### DIFF
--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -194,8 +194,9 @@ variable "health_check_options" {
 }
 
 variable "enable_container_insights" {
-  type    = bool
-  default = false
+  type     = bool
+  default  = false
+  nullable = false
 }
 
 variable "multi_az" {

--- a/ecs/variables.tf
+++ b/ecs/variables.tf
@@ -195,7 +195,7 @@ variable "health_check_options" {
 
 variable "enable_container_insights" {
   type    = bool
-  default = true
+  default = false
 }
 
 variable "multi_az" {

--- a/stack/app/variables.tf
+++ b/stack/app/variables.tf
@@ -371,7 +371,7 @@ variable "health_check_path" { default = "/livez" }
 
 variable "enable_container_insights" {
   type    = bool
-  default = true
+  default = null
 }
 
 variable "health_check_options" {


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

We don't need container insights in most of the apps.

#### Motivation

Lower costs
