### PR TITLE
fix(ecs-service): remove troublesom failure_threshold

### DIFF
--- a/aws/ecs-deploy/service/ecs_service.tf
+++ b/aws/ecs-deploy/service/ecs_service.tf
@@ -122,10 +122,6 @@ resource "aws_service_discovery_service" "main" {
     routing_policy = "MULTIVALUE" # one of MULTIVALUE or WEIGHTED
   }
 
-  health_check_custom_config {
-    failure_threshold = 2 # number between 1 and 10; number of 30 second intervals to wait before declaring failure
-  }
-
   tags = {
     Project     = var.project
     Environment = var.environment


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

setting `failure_threshold` to `2` causes a force-recreated everytime. Removing it will use the default (1).

#### Motivation


https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_service#failure_threshold

https://github.com/hashicorp/terraform-provider-aws/issues/35559