### PR TITLE
chore(azure): allow passing custom names and tags to all resources

### DIFF
--- a/azure/blob-storage/README.md
+++ b/azure/blob-storage/README.md
@@ -4,10 +4,15 @@ https://azure.microsoft.com/en-us/products/storage/blobs
 
 ```
 locals {
-  region = "West Europe"
-  project = "facebook"
+  region              = "West Europe"
+  project             = "facebook"
   resource_group_name = "facebook-staging"
-  environment = "staging"
+  environment         = "staging"
+
+  default_tags = {
+    Project     = local.project
+    Environment = local.environment
+  }
 }
 
 resource "azurerm_resource_group" "main" {
@@ -18,6 +23,7 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_user_assigned_identity" "main" {
   resource_group_name = local.resource_group_name
   location            = local.region
+
   name = local.name
   tags = local.default_tags
 

--- a/azure/blob-storage/main.tf
+++ b/azure/blob-storage/main.tf
@@ -55,7 +55,7 @@ resource "azurerm_storage_account" "main" {
     }
   }
 
-  tags = local.default_tags
+  tags = coalesce(var.tags, local.default_tags)
 }
 
 resource "azurerm_storage_container" "main" {

--- a/azure/blob-storage/variables.tf
+++ b/azure/blob-storage/variables.tf
@@ -146,8 +146,12 @@ variable "cors_config" {
   default = {}
 }
 
+variable "tags" {
+  type    = map(string)
+  default = null
+}
+
 locals {
-  name = "${var.project}-${var.environment}"
   default_tags = {
     Project     = var.project
     Environment = var.environment

--- a/azure/container-app/main.tf
+++ b/azure/container-app/main.tf
@@ -1,5 +1,5 @@
 data "azurerm_container_app_environment" "main" {
-  name                = local.name
+  name                = coalesce(var.container_app_environment_name, local.default_name)
   resource_group_name = var.resource_group_name
 }
 
@@ -9,7 +9,7 @@ data "azurerm_container_registry" "main" {
 }
 
 data "azurerm_key_vault" "main" {
-  name                = local.name
+  name                = coalesce(var.key_vault_name, local.default_name)
   resource_group_name = var.resource_group_name
 }
 
@@ -21,7 +21,7 @@ data "azurerm_key_vault_secret" "main" {
 }
 
 data "azurerm_user_assigned_identity" "main" {
-  name                = local.name
+  name                = coalesce(var.user_assigned_identity_name, local.default_name)
   resource_group_name = var.resource_group_name
 }
 
@@ -71,7 +71,7 @@ resource "azurerm_container_app" "main" {
     max_replicas = var.max_replicas
 
     container {
-      name   = local.name
+      name   = coalesce(var.container_app_name, local.default_name)
       image  = "${data.azurerm_container_registry.main.login_server}:${var.image_version}"
       cpu    = var.cpu
       memory = var.memory
@@ -118,7 +118,7 @@ resource "azurerm_container_app" "main" {
     }
   }
 
-  tags = local.default_tags
+  tags = coalesce(var.tags, local.default_tags)
 }
 
 output "app_url" {

--- a/azure/container-app/variables.tf
+++ b/azure/container-app/variables.tf
@@ -106,8 +106,38 @@ variable "health_check_options" {
   nullable = false
 }
 
+variable "tags" {
+  type    = map(string)
+  default = null
+}
+
+variable "container_app_environment_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment'"
+}
+
+variable "key_vault_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment'"
+}
+
+variable "user_assigned_identity_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment'"
+}
+
+variable "container_app_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment'"
+}
+
 locals {
-  name = "${var.project}-${var.environment}"
+  default_name = "${var.project}-${var.environment}"
+
   default_tags = {
     Project     = var.project
     Environment = var.environment

--- a/azure/container-registry/main.tf
+++ b/azure/container-registry/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_container_registry" "main" {
-  name                          = var.name == null ? var.project : var.name
+  name                          = coalesce(var.name, local.default_name)
   resource_group_name           = var.resource_group_name
   location                      = var.region
   sku                           = var.sku
@@ -31,7 +31,7 @@ resource "azurerm_container_registry" "main" {
     }
   }
 
-  tags = local.default_tags
+  tags = coalesce(var.tags, local.default_tags)
 }
 
 # TODO: Research on the lifecycle policy

--- a/azure/container-registry/variables.tf
+++ b/azure/container-registry/variables.tf
@@ -74,7 +74,7 @@ variable "name" {
 }
 
 locals {
-  default_name = "${var.project}-${var.environment}"
+  default_name = var.project # for security reasons, you should use the same registry name for all environments
 
   default_tags = {
     Project     = var.project

--- a/azure/container-registry/variables.tf
+++ b/azure/container-registry/variables.tf
@@ -2,10 +2,6 @@ variable "resource_group_name" {
   type = string
 }
 
-variable "name" {
-  type = string
-}
-
 variable "region" {
   type = string
 }
@@ -66,8 +62,20 @@ variable "sku" {
   }
 }
 
+variable "tags" {
+  type    = map(string)
+  default = null
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment'."
+}
+
 locals {
-  name = "${var.project}-${var.environment}"
+  default_name = "${var.project}-${var.environment}"
+
   default_tags = {
     Project     = var.project
     Environment = var.environment

--- a/azure/database/postgres/main.tf
+++ b/azure/database/postgres/main.tf
@@ -1,6 +1,6 @@
 # @TODO(sam, lud, 07.03.2024): consider adding HA support, see https://github.com/dbl-works/terraform/pull/316#discussion_r1515101871
 resource "azurerm_postgresql_flexible_server" "main" {
-  name                   = local.name
+  name                   = coalesce(var.db_name, local.default_name)
   resource_group_name    = var.resource_group_name
   location               = var.region
   version                = var.postgres_version
@@ -36,7 +36,7 @@ resource "azurerm_postgresql_flexible_server" "main" {
     ]
   }
 
-  tags = local.default_tags
+  tags = coalesce(var.tags, local.default_tags)
 }
 
 output "id" {

--- a/azure/database/postgres/network.tf
+++ b/azure/database/postgres/network.tf
@@ -4,12 +4,12 @@ data "azurerm_virtual_network" "main" {
 }
 
 resource "azurerm_network_security_group" "main" {
-  name                = "${local.name}-db"
+  name                = coalesce(var.network_security_group_name, "${local.default_name}-db")
   location            = var.region
   resource_group_name = var.resource_group_name
 
   security_rule {
-    name                       = "${local.name}-db"
+    name                       = coalesce(var.network_security_group_name, "${local.default_name}-db")
     priority                   = 1
     direction                  = "Inbound"
     access                     = "Allow"
@@ -20,11 +20,11 @@ resource "azurerm_network_security_group" "main" {
     destination_address_prefix = "*"
   }
 
-  tags = local.default_tags
+  tags = coalesce(var.tags, local.default_tags)
 }
 
 resource "azurerm_subnet" "main" {
-  name                 = "${local.name}-db-subnet"
+  name                 = coalesce(var.subnet_name, "${local.default_name}-db-subnet")
   virtual_network_name = data.azurerm_virtual_network.main.name
   resource_group_name  = var.resource_group_name
   address_prefixes     = var.db_subnet_address_prefixes
@@ -49,10 +49,10 @@ resource "azurerm_subnet_network_security_group_association" "main" {
 }
 
 resource "azurerm_private_dns_zone" "main" {
-  name                = "${local.name}.postgres.database.azure.com"
+  name                = coalesce(var.dns_zone_name, "${local.default_name}.postgres.database.azure.com")
   resource_group_name = var.resource_group_name
 
-  tags = local.default_tags
+  tags = coalesce(var.tags, local.default_tags)
 
   depends_on = [
     azurerm_subnet_network_security_group_association.main

--- a/azure/database/postgres/variables.tf
+++ b/azure/database/postgres/variables.tf
@@ -1,7 +1,3 @@
-variable "name" {
-  type = string
-}
-
 variable "resource_group_name" {
   type = string
 }
@@ -109,8 +105,38 @@ variable "administrator_password" {
   type      = string
 }
 
+variable "tags" {
+  type    = map(string)
+  default = null
+}
+
+variable "db_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment-region'."
+}
+
+variable "network_security_group_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment-region-db'."
+}
+
+variable "subnet_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment-region-db-subnet'."
+}
+
+variable "dns_zone_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment-region.postgres.database.azure.com'."
+}
+
 locals {
-  name = "${var.project}-${var.environment}-${lower(replace(var.region, " ", "-"))}"
+  default_name = "${var.project}-${var.environment}-${lower(replace(var.region, " ", "-"))}"
+
   default_tags = {
     Project     = var.project
     Environment = var.environment

--- a/azure/observability/alerts/main.tf
+++ b/azure/observability/alerts/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_monitor_metric_alert" "cpu" {
-  name                = local.name
+  name                = coalesce(var.monitor_metric_alert_name, local.default_name)
   resource_group_name = var.resource_group_name
   scopes              = [var.container_app_id]
   description         = "Action will be triggered when cpu usage is greater than ${var.cpu_percentage_threshold}"
@@ -17,10 +17,12 @@ resource "azurerm_monitor_metric_alert" "cpu" {
   action {
     action_group_id = azurerm_monitor_action_group.main.id
   }
+
+  tags = coalesce(var.tags, local.default_tags)
 }
 
 resource "azurerm_monitor_metric_alert" "memory" {
-  name                = local.name
+  name                = coalesce(var.monitor_metric_alert_name, local.default_name)
   resource_group_name = var.resource_group_name
   scopes              = [var.container_app_id]
   description         = "Action will be triggered when memory usage is greater than ${var.memory_percentage_threshold}"
@@ -42,12 +44,12 @@ resource "azurerm_monitor_metric_alert" "memory" {
 
 
 resource "azurerm_monitor_action_group" "main" {
-  name                = local.name
+  name                = coalesce(var.monitor_action_group_name, local.default_name)
   resource_group_name = var.resource_group_name
-  short_name          = local.name
+  short_name          = coalesce(var.monitor_action_group_name, local.default_name)
 
   webhook_receiver {
-    name                    = "slack-${local.name}"
+    name                    = "slack-${coalesce(var.monitor_action_group_name, local.default_name)}"
     service_uri             = var.slack_webhook_url
     use_common_alert_schema = true
   }

--- a/azure/observability/alerts/variables.tf
+++ b/azure/observability/alerts/variables.tf
@@ -32,8 +32,26 @@ variable "slack_webhook_url" {
   type = string
 }
 
+variable "tags" {
+  type    = map(string)
+  default = null
+}
+
+variable "monitor_metric_alert_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment'."
+}
+
+variable "monitor_action_group_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment'."
+}
+
 locals {
-  name = "${var.project}-${var.environment}"
+  default_name = "${var.project}-${var.environment}"
+
   default_tags = {
     Project     = var.project
     Environment = var.environment

--- a/azure/observability/monitors/main.tf
+++ b/azure/observability/monitors/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_log_analytics_workspace" "main" {
-  name                = local.name
+  name                = coalesce(var.log_analytics_workspace_name, local.default_name)
   location            = var.resource_group_name
   resource_group_name = var.region
   sku                 = var.sku
@@ -12,7 +12,7 @@ resource "azurerm_log_analytics_workspace" "main" {
 module "blob-storage" {
   source = "../../blob-storage"
 
-  name                       = "${local.name}-monitoring"
+  name                       = coalesce(var.blob_storage_name, "${local.default_name}-monitoring")
   environment                = var.environment
   project                    = var.project
   region                     = var.region
@@ -20,15 +20,15 @@ module "blob-storage" {
   user_assigned_identity_ids = var.user_assigned_identity_ids
 
   lifecycle_rules = {
-    name                                              = "monitoring-${local.name}"
-    prefix_match                                      = ["insights-activity-logs/ResourceId=${var.target_resource_id}"]
+    name                                              = "monitoring-${coalesce(var.blob_storage_name, "${local.default_name}-monitoring")}"
+    prefix_match                                      = ["insights-activity-logs/ResourceId=${var.container_app_id}"]
     blob_types                                        = ["appendBlob"]
     delete_after_days_since_modification_greater_than = var.logs_retention_in_days
   }
 }
 
 resource "azurerm_monitor_diagnostic_setting" "main" {
-  name                       = local.name
+  name                       = coalesce(var.monitor_diagnostic_setting_name, local.default_name)
   target_resource_id         = var.container_app_id
   log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
   storage_account_id         = module.blob-storage.id

--- a/azure/observability/monitors/main.tf
+++ b/azure/observability/monitors/main.tf
@@ -20,10 +20,11 @@ module "blob-storage" {
   user_assigned_identity_ids = var.user_assigned_identity_ids
 
   lifecycle_rules = {
-    name                                              = "monitoring-${coalesce(var.blob_storage_name, "${local.default_name}-monitoring")}"
-    prefix_match                                      = ["insights-activity-logs/ResourceId=${var.container_app_id}"]
-    blob_types                                        = ["appendBlob"]
-    delete_after_days_since_modification_greater_than = var.logs_retention_in_days
+    "monitoring-${coalesce(var.blob_storage_name, "${local.default_name}-monitoring")}" = {
+      prefix_match                                      = ["insights-activity-logs/ResourceId=${var.container_app_id}"]
+      blob_types                                        = ["appendBlob"]
+      delete_after_days_since_modification_greater_than = var.logs_retention_in_days
+    }
   }
 }
 
@@ -31,7 +32,7 @@ resource "azurerm_monitor_diagnostic_setting" "main" {
   name                       = coalesce(var.monitor_diagnostic_setting_name, local.default_name)
   target_resource_id         = var.container_app_id
   log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
-  storage_account_id         = module.blob-storage.id
+  storage_account_id         = module.blob-storage.storage_account_id
 
   # Check here for the list of Service/Category available for different resources
   # https://learn.microsoft.com/en-gb/azure/azure-monitor/essentials/resource-logs-schema#service-specific-schemas

--- a/azure/observability/monitors/variables.tf
+++ b/azure/observability/monitors/variables.tf
@@ -38,8 +38,32 @@ variable "logs_retention_in_days" {
   default  = 90
 }
 
+variable "tags" {
+  type    = map(string)
+  default = null
+}
+
+variable "log_analytics_workspace_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment'."
+}
+
+variable "monitor_diagnostic_setting_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment'."
+}
+
+variable "blob_storage_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment-monitoring'."
+}
+
 locals {
-  name = "${var.project}-${var.environment}"
+  default_name = "${var.project}-${var.environment}"
+
   default_tags = {
     Project     = var.project
     Environment = var.environment

--- a/azure/virtual-network/main.tf
+++ b/azure/virtual-network/main.tf
@@ -1,8 +1,8 @@
 resource "azurerm_virtual_network" "main" {
-  name                = local.name
+  name                = coalesce(var.vnet_name, local.default_name)
   location            = var.region
   resource_group_name = var.resource_group_name
   address_space       = [var.address_space]
 
-  tags = local.default_tags
+  tags = coalesce(var.tags, local.default_tags)
 }

--- a/azure/virtual-network/private-subnet.tf
+++ b/azure/virtual-network/private-subnet.tf
@@ -1,6 +1,6 @@
 # Private subnet prevents incoming traffic.
 resource "azurerm_subnet" "private" {
-  name                 = "${local.name}-private"
+  name                 = coalesce(var.private_subnet_name, "${local.default_name}-private")
   resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.main.name
   # (Assuming address space is 10.0.0.0) range 10.0.100.0 - 10.0.102.255
@@ -8,12 +8,12 @@ resource "azurerm_subnet" "private" {
 }
 
 resource "azurerm_network_interface" "private" {
-  name                = "${local.name}-private"
+  name                = coalesce(var.network_interface_name, "${local.default_name}-private")
   location            = var.region
   resource_group_name = var.resource_group_name
 
   ip_configuration {
-    name                          = "${local.name}-ipconfig"
+    name                          = coalesce(var.network_interface_name, "${local.default_name}-ipconfig")
     subnet_id                     = azurerm_subnet.private.id
     private_ip_address_allocation = "Dynamic"
     public_ip_address_id          = null
@@ -21,7 +21,7 @@ resource "azurerm_network_interface" "private" {
 }
 
 resource "azurerm_network_security_group" "private" {
-  name                = "${local.name}-private"
+  name                = coalesce(var.private_network_security_group_name, "${local.default_name}-private")
   location            = var.region
   resource_group_name = var.resource_group_name
 }

--- a/azure/virtual-network/public-subnet.tf
+++ b/azure/virtual-network/public-subnet.tf
@@ -1,6 +1,6 @@
 # This is the existing public network that allows internet access
 resource "azurerm_subnet" "public" {
-  name                 = "${local.name}-public"
+  name                 = coalesce(var.public_subnet_name, "${local.default_name}-public")
   resource_group_name  = var.resource_group_name
   virtual_network_name = azurerm_virtual_network.main.name
   # (Assuming address space is 10.0.0.0) range 10.0.0.0 - 10.0.2.255
@@ -8,7 +8,7 @@ resource "azurerm_subnet" "public" {
 }
 
 resource "azurerm_network_security_group" "public" {
-  name                = "${local.name}-public"
+  name                = coalesce(var.private_network_security_group_name, "${local.default_name}-public")
   location            = var.region
   resource_group_name = var.resource_group_name
 }

--- a/azure/virtual-network/variables.tf
+++ b/azure/virtual-network/variables.tf
@@ -2,10 +2,6 @@ variable "resource_group_name" {
   type = string
 }
 
-variable "name" {
-  type = string
-}
-
 variable "region" {
   type = string
 }
@@ -50,8 +46,50 @@ variable "public_subnet_config" {
   default = null
 }
 
+variable "tags" {
+  type    = map(string)
+  default = null
+}
+
+variable "vnet_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment'."
+}
+
+variable "public_subnet_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment-public'."
+}
+
+variable "private_subnet_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment-private'."
+}
+
+variable "public_network_security_group_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment-public'."
+}
+
+variable "private_network_security_group_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment-private'."
+}
+
+variable "network_interface_name" {
+  type        = string
+  default     = null
+  description = "Defaults to 'project-environment-ipconfig'."
+}
+
 locals {
-  name = "${var.project}-${var.environment}"
+  default_name = "${var.project}-${var.environment}"
+
   default_tags = {
     Project     = var.project
     Environment = var.environment


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

Allow passing custom names & tags to all Azure modules.

Tags & names always have a default name following the convention of this repo (`${project}-${environment}`).

#### Motivation

<!-- Why are you making this change? -->
