### PR TITLE
chore: bump nodeJS for lambdas from 16 to 20

### DIFF
--- a/aws/cloudwatch-snowflake/main.tf
+++ b/aws/cloudwatch-snowflake/main.tf
@@ -13,9 +13,8 @@ resource "aws_lambda_function" "cloudwatch_metrics_tracker" {
   # Used to trigger updates
   source_code_hash = data.archive_file.zip.output_base64sha256
   handler          = "index.handler"
-  # List of available runtimes: https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
-  runtime = "nodejs16.x"
-  timeout = 300
+  runtime          = "nodejs20.x"
+  timeout          = 300
 
   environment {
     variables = {

--- a/aws/lambda/README.md
+++ b/aws/lambda/README.md
@@ -2,7 +2,6 @@
 
 Used for managing lambda functions.
 
-
 ## Usage
 
 ```terraform
@@ -18,7 +17,7 @@ module "lambda" {
   handler     = "index.handler"
   timeout     = 10
   memory_size = 1024
-  runtime     = "nodejs16.x"
+  runtime     = "nodejs20.x" # https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
 
   # Subnets the lambdas are allowed to use to access resources in the VPC.
   subnet_ids = [


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

bump nodeJS for lambdas from 16 to 20

#### Motivation

AWS is retiring the node 16 runtime.
