### PR TITLE
aws/slack/sentry: Bump sentry version to 0.12.0

### DIFF
--- a/aws/slack/sentry/main.tf
+++ b/aws/slack/sentry/main.tf
@@ -28,7 +28,7 @@ resource "sentry_issue_alert" "main" {
   ]
   EOT
 
-  filters = "[]"
+  # filters = "[]"
 
   # From: https://sentry.io/settings/[org-slug]/integrations/slack/[slack-integration-id]/
   # Or use the sentry_organization_integration data source to retrieve the integration ID:

--- a/aws/slack/sentry/main.tf
+++ b/aws/slack/sentry/main.tf
@@ -19,27 +19,29 @@ resource "sentry_issue_alert" "main" {
   filter_match = "any"
   frequency    = var.frequency
 
-  conditions = [
+  # A new issue is created
+  conditions = <<EOT
+  [
     {
-      # A new issue is created
-      id = "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"
+      "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"
     },
   ]
+  EOT
 
-  filters = []
+  filters = ""
 
-  actions = [
-    # Send a notification to the Slack workspace
+  # From: https://sentry.io/settings/[org-slug]/integrations/slack/[slack-integration-id]/
+  # Or use the sentry_organization_integration data source to retrieve the integration ID:
+  actions = <<EOT
+  [
     {
-      id      = "sentry.integrations.slack.notify_action.SlackNotifyServiceAction"
-      channel = "#ops-${var.project}"
-
-      # From: https://sentry.io/settings/[org-slug]/integrations/slack/[slack-integration-id]/
-      # Or use the sentry_organization_integration data source to retrieve the integration ID:
-      workspace = data.sentry_organization_integration.slack.internal_id
-      tags      = var.tags
-    },
+      "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+      "channel": "#ops-${var.project}",
+      "workspace": ${data.sentry_organization_integration.slack.internal_id},
+      "tags": ${var.tags}
+    }
   ]
+  EOT
 
   depends_on = [
     sentry_project.main

--- a/aws/slack/sentry/main.tf
+++ b/aws/slack/sentry/main.tf
@@ -37,8 +37,8 @@ resource "sentry_issue_alert" "main" {
     {
       "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
       "channel": "#ops-${var.project}",
-      "workspace": ${data.sentry_organization_integration.slack.provider_key},
-      "tags": ${var.tags}
+      "workspace": "${data.sentry_organization_integration.slack.provider_key}",
+      "tags": "${var.tags}"
     }
   ]
   EOT

--- a/aws/slack/sentry/main.tf
+++ b/aws/slack/sentry/main.tf
@@ -28,7 +28,7 @@ resource "sentry_issue_alert" "main" {
   ]
   EOT
 
-  filters = ""
+  filters = "[]"
 
   # From: https://sentry.io/settings/[org-slug]/integrations/slack/[slack-integration-id]/
   # Or use the sentry_organization_integration data source to retrieve the integration ID:

--- a/aws/slack/sentry/main.tf
+++ b/aws/slack/sentry/main.tf
@@ -24,7 +24,7 @@ resource "sentry_issue_alert" "main" {
   [
     {
       "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"
-    },
+    }
   ]
   EOT
 

--- a/aws/slack/sentry/main.tf
+++ b/aws/slack/sentry/main.tf
@@ -37,7 +37,7 @@ resource "sentry_issue_alert" "main" {
     {
       "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
       "channel": "#ops-${var.project}",
-      "workspace": ${data.sentry_organization_integration.provider_key},
+      "workspace": ${data.sentry_organization_integration.slack.provider_key},
       "tags": ${var.tags}
     }
   ]

--- a/aws/slack/sentry/main.tf
+++ b/aws/slack/sentry/main.tf
@@ -37,7 +37,7 @@ resource "sentry_issue_alert" "main" {
     {
       "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
       "channel": "#ops-${var.project}",
-      "workspace": ${data.sentry_organization_integration.slack.internal_id},
+      "workspace": ${data.sentry_organization_integration.provider_key},
       "tags": ${var.tags}
     }
   ]

--- a/aws/slack/sentry/main.tf
+++ b/aws/slack/sentry/main.tf
@@ -37,7 +37,7 @@ resource "sentry_issue_alert" "main" {
     {
       "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
       "channel": "#ops-${var.project}",
-      "workspace": "${data.sentry_organization_integration.slack.provider_key}",
+      "workspace": ${parseint(data.sentry_organization_integration.slack.id, 10)},
       "tags": "${var.tags}"
     }
   ]

--- a/aws/slack/sentry/versions.tf
+++ b/aws/slack/sentry/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     sentry = {
       source  = "jianyuan/sentry"
-      version = ">= 0.11.0"
+      version = ">= 0.12.0"
     }
   }
   required_version = ">= 1.0"

--- a/aws/slack/sentry/versions.tf
+++ b/aws/slack/sentry/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     sentry = {
       source  = "jianyuan/sentry"
-      version = "~> 0.11.0"
+      version = ">= 0.11.0"
     }
   }
   required_version = ">= 1.0"


### PR DESCRIPTION
#### Summary

Bump Sentry version to 0.12.0
There is a huge change for 0.12.0 for sentry issue alert
- https://registry.terraform.io/providers/jianyuan/sentry/latest/docs/resources/issue_alert


#### Motivation

Invalid response from plugin

