### PR TITLE
cloudflare: improve cloudflare security

### DIFF
--- a/aws/multi-stack/app/cloudflare.tf
+++ b/aws/multi-stack/app/cloudflare.tf
@@ -14,5 +14,6 @@ module "cloudflare" {
   # optional
   bastion_enabled    = false
   tls_settings       = var.tls_settings
+  hsts_settings      = var.hsts_settings
   bastion_public_dns = module.ecs.nlb_dns_name
 }

--- a/aws/multi-stack/app/variables.tf
+++ b/aws/multi-stack/app/variables.tf
@@ -58,6 +58,7 @@ variable "project_settings" {
 
 variable "tls_settings" {
   type = object({
+    min_tls_version          = optional(string, null)     # 1.0, 1.1, 1.2, 1.3
     tls_1_3                  = optional(string, "on")     # "on/off"
     automatic_https_rewrites = optional(string, "on")     # "on/off"
     ssl                      = optional(string, "strict") # "strict"

--- a/aws/multi-stack/app/variables.tf
+++ b/aws/multi-stack/app/variables.tf
@@ -59,13 +59,19 @@ variable "project_settings" {
 
 variable "tls_settings" {
   type = object({
-    min_tls_version          = optional(string, null)     # 1.0, 1.1, 1.2, 1.3
+    min_tls_version          = optional(string, "1.2")     # 1.0, 1.1, 1.2, 1.3
     tls_1_3                  = optional(string, "on")     # "on/off"
     automatic_https_rewrites = optional(string, "on")     # "on/off"
     ssl                      = optional(string, "strict") # "strict"
     always_use_https         = optional(string, "on")     # "on/off"
   })
-  default = null
+  default = {
+    min_tls_version           = "1.2"
+    tls_1_3                   = "on"
+    automatic_https_rewrites  = "on"
+    ssl                       = "strict"
+    always_use_https          = "on"
+  }
 }
 
 # HSTS protects HTTPS web servers from downgrade attacks.
@@ -79,7 +85,13 @@ variable "hsts_settings" {
     include_subdomains = optional(bool, null)
     nosniff            = optional(bool, null)
   })
-  default = null
+  default = {
+    enabled            =  true
+    preload            =  true
+    max_age            =  31536000 # Set it to least value for validating functionality.
+    include_subdomains =  true
+    nosniff            =  true
+  }
 }
 
 variable "kms_deletion_window_in_days" {

--- a/aws/multi-stack/app/variables.tf
+++ b/aws/multi-stack/app/variables.tf
@@ -67,6 +67,20 @@ variable "tls_settings" {
   default = null
 }
 
+# HSTS protects HTTPS web servers from downgrade attacks.
+# These attacks redirect web browsers from an HTTPS web server to an attacker-controlled server, allowing bad actors to compromise user data and cookies.
+# https://developers.cloudflare.com/ssl/edge-certificates/additional-options/http-strict-transport-security/
+variable "hsts_settings" {
+  type = object({
+    enabled            = optional(bool, null)
+    preload            = optional(bool, null)
+    max_age            = optional(number, null)
+    include_subdomains = optional(bool, null)
+    nosniff            = optional(bool, null)
+  })
+  default = null
+}
+
 variable "kms_deletion_window_in_days" {
   type = number
 }

--- a/aws/multi-stack/app/variables.tf
+++ b/aws/multi-stack/app/variables.tf
@@ -60,14 +60,14 @@ variable "project_settings" {
 variable "tls_settings" {
   type = object({
     min_tls_version          = optional(string, "1.2")    # 1.0, 1.1, 1.2, 1.3
-    tls_1_3                  = optional(string, "on")     # "on/off"
+    tls_1_3                  = optional(string, "off")    # "on/off"
     automatic_https_rewrites = optional(string, "on")     # "on/off"
     ssl                      = optional(string, "strict") # "strict"
     always_use_https         = optional(string, "on")     # "on/off"
   })
   default = {
     min_tls_version          = "1.2"
-    tls_1_3                  = "on"
+    tls_1_3                  = "off"
     automatic_https_rewrites = "on"
     ssl                      = "strict"
     always_use_https         = "on"

--- a/aws/multi-stack/app/variables.tf
+++ b/aws/multi-stack/app/variables.tf
@@ -43,7 +43,7 @@ variable "project_settings" {
       worker_script_name = string
     })), {})
     host_header       = optional(list(string), null)
-    health_check_path = optional(string, null)
+    health_check_path = optional(string, "/livez")
     health_check_options = optional(
       object({
         healthy_threshold   = optional(number, 2)  # The number of consecutive health checks successes required before considering an unhealthy target healthy.

--- a/aws/multi-stack/app/variables.tf
+++ b/aws/multi-stack/app/variables.tf
@@ -59,18 +59,18 @@ variable "project_settings" {
 
 variable "tls_settings" {
   type = object({
-    min_tls_version          = optional(string, "1.2")     # 1.0, 1.1, 1.2, 1.3
+    min_tls_version          = optional(string, "1.2")    # 1.0, 1.1, 1.2, 1.3
     tls_1_3                  = optional(string, "on")     # "on/off"
     automatic_https_rewrites = optional(string, "on")     # "on/off"
     ssl                      = optional(string, "strict") # "strict"
     always_use_https         = optional(string, "on")     # "on/off"
   })
   default = {
-    min_tls_version           = "1.2"
-    tls_1_3                   = "on"
-    automatic_https_rewrites  = "on"
-    ssl                       = "strict"
-    always_use_https          = "on"
+    min_tls_version          = "1.2"
+    tls_1_3                  = "on"
+    automatic_https_rewrites = "on"
+    ssl                      = "strict"
+    always_use_https         = "on"
   }
 }
 
@@ -86,11 +86,11 @@ variable "hsts_settings" {
     nosniff            = optional(bool, null)
   })
   default = {
-    enabled            =  true
-    preload            =  true
-    max_age            =  31536000 # Set it to least value for validating functionality.
-    include_subdomains =  true
-    nosniff            =  true
+    enabled            = true
+    preload            = true
+    max_age            = 31536000 # Set it to least value for validating functionality.
+    include_subdomains = true
+    nosniff            = true
   }
 }
 

--- a/aws/stack/app/cloudflare.tf
+++ b/aws/stack/app/cloudflare.tf
@@ -14,5 +14,6 @@ module "cloudflare" {
   # optional
   bastion_enabled    = true
   tls_settings       = var.tls_settings
+  hsts_settings      = var.hsts_settings
   bastion_public_dns = module.ecs.nlb_dns_name
 }

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -50,18 +50,18 @@ variable "s3_cloudflare_records" {
 
 variable "tls_settings" {
   type = object({
-    min_tls_version          = optional(string, "1.2")     # 1.0, 1.1, 1.2, 1.3
+    min_tls_version          = optional(string, "1.2")    # 1.0, 1.1, 1.2, 1.3
     tls_1_3                  = optional(string, "on")     # "on/off"
     automatic_https_rewrites = optional(string, "on")     # "on/off"
     ssl                      = optional(string, "strict") # "strict"
     always_use_https         = optional(string, "on")     # "on/off"
   })
   default = {
-    min_tls_version           = "1.2"
-    tls_1_3                   = "on"
-    automatic_https_rewrites  = "on"
-    ssl                       = "strict"
-    always_use_https          = "on"
+    min_tls_version          = "1.2"
+    tls_1_3                  = "on"
+    automatic_https_rewrites = "on"
+    ssl                      = "strict"
+    always_use_https         = "on"
   }
 }
 
@@ -77,11 +77,11 @@ variable "hsts_settings" {
     nosniff            = optional(bool, null)
   })
   default = {
-    enabled            =  true
-    preload            =  true
-    max_age            =  31536000 # Set it to least value for validating functionality.
-    include_subdomains =  true
-    nosniff            =  true
+    enabled            = true
+    preload            = true
+    max_age            = 31536000 # Set it to least value for validating functionality.
+    include_subdomains = true
+    nosniff            = true
   }
 }
 # =============== Cloudflare ================ #

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -58,6 +58,20 @@ variable "tls_settings" {
   })
   default = null
 }
+
+# HSTS protects HTTPS web servers from downgrade attacks.
+# These attacks redirect web browsers from an HTTPS web server to an attacker-controlled server, allowing bad actors to compromise user data and cookies.
+# https://developers.cloudflare.com/ssl/edge-certificates/additional-options/http-strict-transport-security/
+variable "hsts_settings" {
+  type = object({
+    enabled            = optional(bool, null)
+    preload            = optional(bool, null)
+    max_age            = optional(number, null)
+    include_subdomains = optional(bool, null)
+    nosniff            = optional(bool, null)
+  })
+  default = null
+}
 # =============== Cloudflare ================ #
 
 # =============== S3 private ================ #

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -50,13 +50,19 @@ variable "s3_cloudflare_records" {
 
 variable "tls_settings" {
   type = object({
-    min_tls_version          = optional(string, null) # 1.0, 1.1, 1.2, 1.3
-    tls_1_3                  = string                 # "on/off"
-    automatic_https_rewrites = string                 # "on/off"
-    ssl                      = string                 # "strict"
-    always_use_https         = string                 # "on/off"
+    min_tls_version          = optional(string, "1.2")     # 1.0, 1.1, 1.2, 1.3
+    tls_1_3                  = optional(string, "on")     # "on/off"
+    automatic_https_rewrites = optional(string, "on")     # "on/off"
+    ssl                      = optional(string, "strict") # "strict"
+    always_use_https         = optional(string, "on")     # "on/off"
   })
-  default = null
+  default = {
+    min_tls_version           = "1.2"
+    tls_1_3                   = "on"
+    automatic_https_rewrites  = "on"
+    ssl                       = "strict"
+    always_use_https          = "on"
+  }
 }
 
 # HSTS protects HTTPS web servers from downgrade attacks.
@@ -70,7 +76,13 @@ variable "hsts_settings" {
     include_subdomains = optional(bool, null)
     nosniff            = optional(bool, null)
   })
-  default = null
+  default = {
+    enabled            =  true
+    preload            =  true
+    max_age            =  31536000 # Set it to least value for validating functionality.
+    include_subdomains =  true
+    nosniff            =  true
+  }
 }
 # =============== Cloudflare ================ #
 

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -50,10 +50,11 @@ variable "s3_cloudflare_records" {
 
 variable "tls_settings" {
   type = object({
-    tls_1_3                  = string # "on/off"
-    automatic_https_rewrites = string # "on/off"
-    ssl                      = string # "strict"
-    always_use_https         = string # "on/off"
+    min_tls_version          = optional(string, null) # 1.0, 1.1, 1.2, 1.3
+    tls_1_3                  = string                 # "on/off"
+    automatic_https_rewrites = string                 # "on/off"
+    ssl                      = string                 # "strict"
+    always_use_https         = string                 # "on/off"
   })
   default = null
 }

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -51,14 +51,14 @@ variable "s3_cloudflare_records" {
 variable "tls_settings" {
   type = object({
     min_tls_version          = optional(string, "1.2")    # 1.0, 1.1, 1.2, 1.3
-    tls_1_3                  = optional(string, "on")     # "on/off"
+    tls_1_3                  = optional(string, "off")    # "on/off"
     automatic_https_rewrites = optional(string, "on")     # "on/off"
     ssl                      = optional(string, "strict") # "strict"
     always_use_https         = optional(string, "on")     # "on/off"
   })
   default = {
     min_tls_version          = "1.2"
-    tls_1_3                  = "on"
+    tls_1_3                  = "off"
     automatic_https_rewrites = "on"
     ssl                      = "strict"
     always_use_https         = "on"

--- a/cloudflare/tls.tf
+++ b/cloudflare/tls.tf
@@ -13,5 +13,6 @@ resource "cloudflare_zone_settings_override" "tls" {
     automatic_https_rewrites = var.tls_settings.automatic_https_rewrites
     ssl                      = var.tls_settings.ssl
     always_use_https         = var.tls_settings.always_use_https
+    security_header          = var.hsts_settings
   }
 }

--- a/cloudflare/tls.tf
+++ b/cloudflare/tls.tf
@@ -13,6 +13,13 @@ resource "cloudflare_zone_settings_override" "tls" {
     automatic_https_rewrites = var.tls_settings.automatic_https_rewrites
     ssl                      = var.tls_settings.ssl
     always_use_https         = var.tls_settings.always_use_https
-    security_header          = var.hsts_settings
+
+    security_header {
+      enabled            = var.hsts_settings.enabled
+      include_subdomains = var.hsts_settings.include_subdomains
+      max_age            = var.hsts_settings.max_age
+      nosniff            = var.hsts_settings.nosniff
+      preload            = var.hsts_settings.preload
+    }
   }
 }

--- a/cloudflare/tls.tf
+++ b/cloudflare/tls.tf
@@ -9,6 +9,7 @@ resource "cloudflare_zone_settings_override" "tls" {
 
   settings {
     tls_1_3                  = var.tls_settings.tls_1_3
+    min_tls_version          = var.tls_settings.min_tls_version
     automatic_https_rewrites = var.tls_settings.automatic_https_rewrites
     ssl                      = var.tls_settings.ssl
     always_use_https         = var.tls_settings.always_use_https

--- a/cloudflare/variables.tf
+++ b/cloudflare/variables.tf
@@ -14,7 +14,7 @@ variable "bastion_enabled" {
 
 variable "tls_settings" {
   type = object({
-    min_tls_version          = optional(string, "1.3") # 1.0, 1.1, 1.2, 1.3
+    min_tls_version          = optional(string, "1.2") # 1.0, 1.1, 1.2, 1.3
     tls_1_3                  = string                  # "on/off"
     automatic_https_rewrites = string                  # "on/off"
     ssl                      = string                  # "strict"

--- a/cloudflare/variables.tf
+++ b/cloudflare/variables.tf
@@ -29,8 +29,8 @@ variable "tls_settings" {
 variable "hsts_settings" {
   type = object({
     enabled            = optional(bool, true)
-    preload            = optional(bool, false)
-    max_age            = optional(number, 31536000)
+    preload            = optional(bool, true)       # Initially disable until you are sure about your configuration
+    max_age            = optional(number, 31536000) # Set it to least value for validating functionality.
     include_subdomains = optional(bool, true)
     nosniff            = optional(bool, true)
   })

--- a/cloudflare/variables.tf
+++ b/cloudflare/variables.tf
@@ -14,10 +14,11 @@ variable "bastion_enabled" {
 
 variable "tls_settings" {
   type = object({
-    tls_1_3                  = string # "on/off"
-    automatic_https_rewrites = string # "on/off"
-    ssl                      = string # "strict"
-    always_use_https         = string # "on/off"
+    min_tls_version          = optional(string, "1.3") # 1.0, 1.1, 1.2, 1.3
+    tls_1_3                  = string                  # "on/off"
+    automatic_https_rewrites = string                  # "on/off"
+    ssl                      = string                  # "strict"
+    always_use_https         = string                  # "on/off"
   })
   default = null
 }

--- a/cloudflare/variables.tf
+++ b/cloudflare/variables.tf
@@ -23,6 +23,20 @@ variable "tls_settings" {
   default = null
 }
 
+# HSTS protects HTTPS web servers from downgrade attacks.
+# These attacks redirect web browsers from an HTTPS web server to an attacker-controlled server, allowing bad actors to compromise user data and cookies.
+# https://developers.cloudflare.com/ssl/edge-certificates/additional-options/http-strict-transport-security/
+variable "hsts_settings" {
+  type = object({
+    enabled            = optional(bool, true)
+    preload            = optional(bool, false)
+    max_age            = optional(number, 31536000)
+    include_subdomains = optional(bool, true)
+    nosniff            = optional(bool, true)
+  })
+  default = null
+}
+
 variable "alb_dns_name" {
   type = string
 }


### PR DESCRIPTION
#### Summary

Set minimum tls version to 1.3, and enable hsts setting


#### Motivation

<!-- Why are you making this change? -->
