### PR TITLE
aws/stack/global: fix billing alarm region

### DIFF
--- a/aws/stack/global/billing-alerts.tf
+++ b/aws/stack/global/billing-alerts.tf
@@ -1,4 +1,6 @@
 resource "aws_cloudwatch_metric_alarm" "account_billing_alarm" {
+  provider = aws.us-east-1
+
   alarm_name          = "account-billing-alarm"
   alarm_description   = "Billing consolidated alarm >= USD ${var.monthly_billing_threshold}"
   comparison_operator = "GreaterThanOrEqualToThreshold"


### PR DESCRIPTION
#### Summary

Metric alarm and sns topic has to be in the same region

#### Motivation

<!-- Why are you making this change? -->
