### PR TITLE
aws/elasticache: allow parameter_group_name to be null

### DIFF
--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -30,8 +30,9 @@ variable "node_count" {
 }
 
 variable "parameter_group_name" {
-  type    = string
-  default = null # "default.redis7.cluster.on"
+  type        = string
+  default     = null
+  description = "Use default.redis7.cluster.on, for Redis (cluster mode enabled) clusters and replication groups. Use default.redis7, for Redis (cluster mode disabled) clusters and replication groups."
 }
 
 variable "major_version" {

--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -31,7 +31,7 @@ variable "node_count" {
 
 variable "parameter_group_name" {
   type    = string
-  default = null
+  default = null # "default.redis7.cluster.on"
 }
 
 variable "major_version" {

--- a/aws/multi-stack/app/variables.tf
+++ b/aws/multi-stack/app/variables.tf
@@ -93,7 +93,7 @@ variable "elasticache_config" {
     major_version                = optional(number, 7)
     minor_version                = optional(number, 0)
     node_count                   = optional(number, 1)
-    parameter_group_name         = optional(string, null) # "default.redis7.cluster.on"
+    parameter_group_name         = optional(string, null) # Use default.redis7.cluster.on, for Redis (cluster mode enabled) clusters and replication groups. Use default.redis7, for Redis (cluster mode disabled) clusters and replication groups.
     replicas_per_node_group      = optional(number, 1)
     shards_per_replication_group = optional(number, 1)
     data_tiering_enabled         = optional(bool, false)

--- a/aws/multi-stack/app/variables.tf
+++ b/aws/multi-stack/app/variables.tf
@@ -93,7 +93,7 @@ variable "elasticache_config" {
     major_version                = optional(number, 7)
     minor_version                = optional(number, 0)
     node_count                   = optional(number, 1)
-    parameter_group_name         = optional(string, "default.redis7.cluster.on")
+    parameter_group_name         = optional(string, null) # "default.redis7.cluster.on"
     replicas_per_node_group      = optional(number, 1)
     shards_per_replication_group = optional(number, 1)
     data_tiering_enabled         = optional(bool, false)

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -182,8 +182,9 @@ variable "elasticache_node_count" {
 }
 
 variable "elasticache_parameter_group_name" {
-  type    = string
-  default = "default.redis7.cluster.on"
+  type        = string
+  default     = null
+  description = "Use default.redis7.cluster.on, for Redis (cluster mode enabled) clusters and replication groups. Use default.redis7, for Redis (cluster mode disabled) clusters and replication groups."
 }
 
 variable "elasticache_replicas_per_node_group" {


### PR DESCRIPTION
#### Summary

<!-- What does the code do? What have you changed? Consider adding before/after screenshots or command line logs. What is the current behavior? What is the expected behavior? -->

#### Motivation
aws_elasticache_parameter_group will only be created if parameter_group_name is null

See [here](https://github.com/dbl-works/terraform/blob/main/aws/elasticache/elasticache.tf#L92)
