### PR TITLE
aws/cloudwatch-kinesis: replace subscription_log_group_name with subscription_log_group_names

### DIFF
--- a/aws/cloudwatch-kinesis/README.md
+++ b/aws/cloudwatch-kinesis/README.md
@@ -28,7 +28,7 @@ module "cloudwatch-kinesis" {
   # Optional
   kinesis_stream_name = "kinesis-aws"
   region = "us-east-1"
-  subscription_log_group_name = "/ecs/facebook-staging"
+  subscription_log_group_names = ["/ecs/facebook-staging"]
   s3_output_prefix = "raw/"
   s3_error_output_prefix = "errors/"
   enable_dynamic_partitioning = true

--- a/aws/cloudwatch-kinesis/cloudwatch-subscription-filter.tf
+++ b/aws/cloudwatch-kinesis/cloudwatch-subscription-filter.tf
@@ -40,9 +40,11 @@ resource "aws_iam_role_policy_attachment" "subscription_filter" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "subscription_filter" {
+  for_each = { for idx, name in var.subscription_log_group_names : name => idx }
+
   name            = local.name
   role_arn        = aws_iam_role.subscription_filter.arn
   filter_pattern  = var.subscription_filter_pattern
-  log_group_name  = var.subscription_log_group_name
+  log_group_name  = each.key
   destination_arn = aws_kinesis_firehose_delivery_stream.main.arn
 }

--- a/aws/cloudwatch-kinesis/variables.tf
+++ b/aws/cloudwatch-kinesis/variables.tf
@@ -69,8 +69,8 @@ variable "s3_configuration" {
   default = null
 }
 
-variable "subscription_log_group_name" {
-  type = string
+variable "subscription_log_group_names" {
+  type = list(string)
 }
 
 variable "kinesis_stream_name" {


### PR DESCRIPTION
#### Summary

Allow list of cloudwatch log group names to be passed into the module

#### Motivation

<!-- Why are you making this change? -->
