### PR TITLE
aws/ecs: allow alb subnet to be defined

### DIFF
--- a/aws/ecs/alb.tf
+++ b/aws/ecs/alb.tf
@@ -3,7 +3,7 @@ resource "aws_alb" "alb" {
   name = local.name
 
   # At least two subnets in two different Availability Zones must be specified
-  subnets = slice(var.subnet_public_ids, 0, var.no_of_subnets_in_alb)
+  subnets = var.alb_subnet_ids
 
   security_groups = [
     aws_security_group.alb.id,

--- a/aws/ecs/nlb.tf
+++ b/aws/ecs/nlb.tf
@@ -3,7 +3,7 @@ resource "aws_lb" "nlb" {
   name               = "${local.name}-nlb"
   load_balancer_type = "network"
   # The NLB is configured for single-region deployment as it serves developer-only purposes, and we accept the associated downtime risks.
-  subnets      = [var.nlb_subnet_id]
+  subnets      = var.nlb_subnet_ids
   idle_timeout = var.keep_alive_timeout
   tags = {
     Name        = "${local.name}-nlb"

--- a/aws/ecs/nlb.tf
+++ b/aws/ecs/nlb.tf
@@ -3,7 +3,7 @@ resource "aws_lb" "nlb" {
   name               = "${local.name}-nlb"
   load_balancer_type = "network"
   # The NLB is configured for single-region deployment as it serves developer-only purposes, and we accept the associated downtime risks.
-  subnets      = [var.subnet_public_ids[0]]
+  subnets      = [var.nlb_subnet_id]
   idle_timeout = var.keep_alive_timeout
   tags = {
     Name        = "${local.name}-nlb"

--- a/aws/ecs/outputs.tf
+++ b/aws/ecs/outputs.tf
@@ -12,6 +12,10 @@ output "alb_arn" {
   value = aws_alb.alb.arn
 }
 
+output "nlb_arn" {
+  value = aws_alb.nlb.arn
+}
+
 output "nlb_dns_name" {
   value = length(aws_lb.nlb) > 0 ? aws_lb.nlb[0].dns_name : null
 }

--- a/aws/ecs/outputs.tf
+++ b/aws/ecs/outputs.tf
@@ -3,6 +3,15 @@ output "alb_dns_name" {
   value = aws_alb.alb.dns_name
 }
 
+# Need this for the usage of cloudwatch metrics
+output "alb_arn_suffix" {
+  value = aws_alb.alb.arn_suffix
+}
+
+output "alb_arn" {
+  value = aws_alb.alb.arn
+}
+
 output "nlb_dns_name" {
   value = length(aws_lb.nlb) > 0 ? aws_lb.nlb[0].dns_name : null
 }
@@ -28,11 +37,6 @@ output "ecs_security_group_id" {
 # Needed to attach additional ressources (e.g. certificates) to the ALB
 output "https_alb_listener_arn" {
   value = aws_alb_listener.https.arn
-}
-
-# Need this for the usage of cloudwatch metrics
-output "alb_arn_suffix" {
-  value = aws_alb.alb.arn_suffix
 }
 
 output "ecs_cluster_name" {

--- a/aws/ecs/variables.tf
+++ b/aws/ecs/variables.tf
@@ -45,9 +45,6 @@ variable "allow_alb_traffic_to_ports" {
   nullable = false
 }
 
-# Public subnets are where forwarders run, such as a bastion, NAT or proxy
-variable "subnet_public_ids" { type = list(string) }
-
 # Allow containers to access the following resources from inside the cluster
 variable "secrets_arns" {
   type    = list(string)
@@ -215,13 +212,14 @@ variable "enable_container_insights" {
   nullable = false
 }
 
-variable "multi_az" {
-  type    = bool
-  default = false
+variable "alb_subnet_ids" {
+  type = list(string)
+  validation {
+    condition     = length(var.alb_subnet_ids) >= 2
+    error_message = "At least two subnets in two different Availability Zones must be specified"
+  }
 }
 
-variable "no_of_subnets_in_alb" {
-  type     = number
-  nullable = false
-  default  = 2
+variable "nlb_subnet_id" {
+  type = string
 }

--- a/aws/ecs/variables.tf
+++ b/aws/ecs/variables.tf
@@ -216,7 +216,7 @@ variable "alb_subnet_ids" {
   type = list(string)
   validation {
     condition     = length(var.alb_subnet_ids) >= 2
-    error_message = "At least two subnets in two different Availability Zones must be specified"
+    error_message = "At least two subnets in two different Availability Zones must be specified (AWS limitation)."
   }
 }
 

--- a/aws/ecs/variables.tf
+++ b/aws/ecs/variables.tf
@@ -220,6 +220,6 @@ variable "alb_subnet_ids" {
   }
 }
 
-variable "nlb_subnet_id" {
-  type = string
+variable "nlb_subnet_ids" {
+  type = list(string)
 }

--- a/aws/multi-stack/app/ecs.tf
+++ b/aws/multi-stack/app/ecs.tf
@@ -31,7 +31,7 @@ module "ecs" {
   environment    = var.environment
   vpc_id         = module.vpc.id
   alb_subnet_ids = var.ecs_config.alb_subnet_type == "private" ? module.vpc.subnet_private_ids : module.vpc.subnet_public_ids
-  nlb_subnet_id  = module.vpc.subnet_public_ids[0]
+  nlb_subnet_ids = [module.vpc.subnet_public_ids[0]]
   secrets_arns = flatten([
     toset(values(data.aws_secretsmanager_secret.app).*.arn),
     var.ecs_config.secret_arns

--- a/aws/multi-stack/app/ecs.tf
+++ b/aws/multi-stack/app/ecs.tf
@@ -30,7 +30,8 @@ module "ecs" {
   project           = var.project
   environment       = var.environment
   vpc_id            = module.vpc.id
-  subnet_public_ids = module.vpc.subnet_public_ids
+  alb_subnet_ids    = var.ecs_config.alb_subnet_type == "private" ? module.vpc.subnet_private_ids : module.vpc.subnet_public_ids
+  nlb_subnet_id     = module.vpc.subnet_public_ids[0]
   secrets_arns = flatten([
     toset(values(data.aws_secretsmanager_secret.app).*.arn),
     var.ecs_config.secret_arns

--- a/aws/multi-stack/app/ecs.tf
+++ b/aws/multi-stack/app/ecs.tf
@@ -27,11 +27,11 @@ locals {
 module "ecs" {
   source = "../../ecs"
 
-  project           = var.project
-  environment       = var.environment
-  vpc_id            = module.vpc.id
-  alb_subnet_ids    = var.ecs_config.alb_subnet_type == "private" ? module.vpc.subnet_private_ids : module.vpc.subnet_public_ids
-  nlb_subnet_id     = module.vpc.subnet_public_ids[0]
+  project        = var.project
+  environment    = var.environment
+  vpc_id         = module.vpc.id
+  alb_subnet_ids = var.ecs_config.alb_subnet_type == "private" ? module.vpc.subnet_private_ids : module.vpc.subnet_public_ids
+  nlb_subnet_id  = module.vpc.subnet_public_ids[0]
   secrets_arns = flatten([
     toset(values(data.aws_secretsmanager_secret.app).*.arn),
     var.ecs_config.secret_arns

--- a/aws/multi-stack/app/variables.tf
+++ b/aws/multi-stack/app/variables.tf
@@ -30,6 +30,7 @@ variable "ecs_config" {
     secret_arns                       = optional(list(string), [])
     allowlisted_ssh_ips               = optional(list(string), null)
     service_discovery_enabled         = optional(bool, null)
+    alb_subnet_type                   = optional(string, "public")
   })
 }
 

--- a/aws/stack/app/ecs.tf
+++ b/aws/stack/app/ecs.tf
@@ -9,7 +9,8 @@ module "ecs" {
   project           = var.project
   environment       = var.environment
   vpc_id            = module.vpc.id
-  subnet_public_ids = module.vpc.subnet_public_ids
+  alb_subnet_ids    = var.alb_subnet_type == "private" ? module.vpc.subnet_private_ids : module.vpc.subnet_public_ids
+  nlb_subnet_id     = module.vpc.subnet_public_ids[0]
   secrets_arns = flatten([
     data.aws_secretsmanager_secret.app.arn,
     var.secret_arns
@@ -35,9 +36,6 @@ module "ecs" {
   allow_internal_traffic_to_ports = var.allow_internal_traffic_to_ports
   allow_alb_traffic_to_ports      = var.allow_alb_traffic_to_ports
   alb_listener_rules              = var.alb_listener_rules
-
-  multi_az             = var.ecs_multi_az
-  no_of_subnets_in_alb = var.no_of_subnets_in_alb
 
   allowlisted_ssh_ips = distinct(flatten(concat([
     var.allowlisted_ssh_ips,

--- a/aws/stack/app/ecs.tf
+++ b/aws/stack/app/ecs.tf
@@ -10,7 +10,7 @@ module "ecs" {
   environment    = var.environment
   vpc_id         = module.vpc.id
   alb_subnet_ids = var.alb_subnet_type == "private" ? module.vpc.subnet_private_ids : module.vpc.subnet_public_ids
-  nlb_subnet_id  = module.vpc.subnet_public_ids[0]
+  nlb_subnet_ids = [module.vpc.subnet_public_ids[0]]
   secrets_arns = flatten([
     data.aws_secretsmanager_secret.app.arn,
     var.secret_arns

--- a/aws/stack/app/ecs.tf
+++ b/aws/stack/app/ecs.tf
@@ -6,11 +6,11 @@ data "aws_acm_certificate" "default" {
 module "ecs" {
   source = "../../ecs"
 
-  project           = var.project
-  environment       = var.environment
-  vpc_id            = module.vpc.id
-  alb_subnet_ids    = var.alb_subnet_type == "private" ? module.vpc.subnet_private_ids : module.vpc.subnet_public_ids
-  nlb_subnet_id     = module.vpc.subnet_public_ids[0]
+  project        = var.project
+  environment    = var.environment
+  vpc_id         = module.vpc.id
+  alb_subnet_ids = var.alb_subnet_type == "private" ? module.vpc.subnet_private_ids : module.vpc.subnet_public_ids
+  nlb_subnet_id  = module.vpc.subnet_public_ids[0]
   secrets_arns = flatten([
     data.aws_secretsmanager_secret.app.arn,
     var.secret_arns

--- a/aws/stack/app/outputs.tf
+++ b/aws/stack/app/outputs.tf
@@ -69,6 +69,10 @@ output "alb_dns_name" {
   value = module.ecs.alb_dns_name
 }
 
+output "alb_arn" {
+  value = module.ecs.alb_arn
+}
+
 output "nlb_dns_name" {
   value = module.ecs.nlb_dns_name
 }

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -460,7 +460,7 @@ variable "alb_subnet_type" {
   type    = string
   default = "public"
   validation {
-    condition     = contains(["public", "private"], var.subnet_type)
+    condition     = contains(["public", "private"], var.alb_subnet_type)
     error_message = "subnet_type must be either public or private"
   }
 }

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -456,16 +456,15 @@ variable "ecs_custom_policies" {
   default = []
 }
 
-variable "no_of_subnets_in_alb" {
-  type    = number
-  default = null
+variable "alb_subnet_type" {
+  type    = string
+  default = "public"
+  validation {
+    condition     = contains(["public", "private"], var.subnet_type)
+    error_message = "subnet_type must be either public or private"
+  }
 }
 
-variable "ecs_multi_az" {
-  type        = bool
-  default     = false
-  description = "multi-az for load balancers"
-}
 
 variable "additional_certificate_arns" {
   description = "Additional certificates to add to the load balancer"


### PR DESCRIPTION
#### Summary

- Allow alb subnet to be defined in the ecs module
- Allow alb subnet type to be defined in the stack module


#### Motivation
allow the alb to be placed in the private subnet so its endpoint will not be accessible on internet

