### PR TITLE
aws/ecs: take out s3 policy for alb access logs

### DIFF
--- a/aws/ecs/alb.tf
+++ b/aws/ecs/alb.tf
@@ -26,58 +26,6 @@ resource "aws_alb" "alb" {
   }
 }
 
-# Access logs
-data "aws_elb_service_account" "main" {}
-
-data "aws_iam_policy_document" "lb_logs" {
-  policy_id = "lb_logs"
-
-  statement {
-    actions = [
-      "s3:PutObject",
-    ]
-    effect    = "Allow"
-    resources = ["arn:aws:s3:::${var.access_logs_bucket}/${var.access_logs_prefix}/*"]
-
-    principals {
-      identifiers = ["${data.aws_elb_service_account.main.arn}"]
-      type        = "AWS"
-    }
-  }
-
-  statement {
-    actions = [
-      "s3:PutObject"
-    ]
-    effect    = "Allow"
-    resources = ["arn:aws:s3:::${var.access_logs_bucket}/${var.access_logs_prefix}/*"]
-    principals {
-      identifiers = ["delivery.logs.amazonaws.com"]
-      type        = "Service"
-    }
-  }
-
-
-  statement {
-    actions = [
-      "s3:GetBucketAcl"
-    ]
-    effect    = "Allow"
-    resources = ["arn:aws:s3:::${var.access_logs_bucket}"]
-    principals {
-      identifiers = ["delivery.logs.amazonaws.com"]
-      type        = "Service"
-    }
-  }
-}
-
-resource "aws_s3_bucket_policy" "lb-logs" {
-  count = var.enable_access_logs ? 1 : 0
-
-  bucket = var.access_logs_bucket
-  policy = data.aws_iam_policy_document.lb_logs.json
-}
-
 resource "aws_alb_listener" "http" {
   load_balancer_arn = aws_alb.alb.id
   port              = "80"


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

Other terraform implementation will overwrite the Bucket policy, so it would be nicer if we take it out.

<!-- What does the code do? What have you changed? Consider adding before/after screenshots or command line logs. What is the current behavior? What is the expected behavior? -->

#### Motivation

<!-- Why are you making this change? -->
