### PR TITLE
aws/s3-private: remove compact

### DIFF
--- a/aws/s3-private/replication.tf
+++ b/aws/s3-private/replication.tf
@@ -73,7 +73,7 @@ locals {
       ]
     },
   ]
-  encrypt-policy = compact([
+  encrypt-policy = [
     for replica in var.s3_replicas : {
       "Effect" : "Allow",
       "Action" : [
@@ -87,7 +87,7 @@ locals {
       },
       "Resource" : [replica.kms_arn]
     } if replica.kms_arn != null
-  ])
+  ]
 }
 
 resource "aws_iam_policy" "replication" {


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary
compact cannot be used to remove null value from a list of objects
<!-- What does the code do? What have you changed? Consider adding before/after screenshots or command line logs. What is the current behavior? What is the expected behavior? -->

#### Motivation

<!-- Why are you making this change? -->
