### PR TITLE
fix(aws/ecs): ensure we don't pass a NULL object to the policy builder

### DIFF
--- a/aws/ecs/execution-role.tf
+++ b/aws/ecs/execution-role.tf
@@ -149,10 +149,10 @@ resource "aws_iam_role_policy" "ecs-task-execution-policy" {
 }
 
 locals {
-  kms_and_secret_arns = flatten([
+  kms_and_secret_arns = compact(flatten([
     var.secrets_arns,
     var.kms_key_arns,
-  ])
+  ]))
 }
 
 # Making secret/kms ARNs optional was added later.


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

The ECS execution role could fail if one of the passed args (secrets or KMS keys) are a NULL object. Terraform's `flatten` does not remove NULL entries, and they blow up the policy.

#### Motivation

<!-- Why are you making this change? -->
