### PR TITLE
fix(aws, stack): elasticache_transit_encryption_mode

### DIFF
--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -87,7 +87,7 @@ variable "transit_encryption_mode" {
   description = "when migrating from no encryption to encryption, this must be set to 'preferred', then apply changes, then set to 'required'"
 
   validation {
-    condition     = contains(["required", "preferred", null], var.transit_encryption_mode)
+    condition     = var.transit_encryption_mode == null || contains(["required", "preferred"], var.transit_encryption_mode)
     error_message = "transit_encryption_mode must be either 'required' or 'preferred'"
   }
 }

--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -82,13 +82,13 @@ variable "transit_encryption_enabled" {
 }
 
 variable "transit_encryption_mode" {
-  type    = string
-  default = "required"
-  # nullable    = true
+  type        = string
+  default     = "required"
+  nullable    = true
   description = "when migrating from no encryption to encryption, this must be set to 'preferred', then apply changes, then set to 'required'"
 
   validation {
-    condition     = var.transit_encryption_mode == null || contains(["required", "preferred"], var.transit_encryption_mode)
+    condition     = var.transit_encryption_mode == null || var.transit_encryption_mode == "required" || var.transit_encryption_mode == "preferred"
     error_message = "transit_encryption_mode must be either 'required' or 'preferred'"
   }
 }

--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -82,9 +82,9 @@ variable "transit_encryption_enabled" {
 }
 
 variable "transit_encryption_mode" {
-  type        = string
-  default     = "required"
-  nullable    = true
+  type    = string
+  default = "required"
+  # nullable    = true
   description = "when migrating from no encryption to encryption, this must be set to 'preferred', then apply changes, then set to 'required'"
 
   validation {

--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -84,6 +84,7 @@ variable "transit_encryption_enabled" {
 variable "transit_encryption_mode" {
   type        = string
   default     = "required"
+  nullable    = true
   description = "when migrating from no encryption to encryption, this must be set to 'preferred', then apply changes, then set to 'required'"
 
   validation {

--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -87,7 +87,7 @@ variable "transit_encryption_mode" {
   description = "when migrating from no encryption to encryption, this must be set to 'preferred', then apply changes, then set to 'required'"
 
   validation {
-    condition     = contains(["required", "preferred"], var.transit_encryption_mode)
+    condition     = contains(["required", "preferred", null], var.transit_encryption_mode)
     error_message = "transit_encryption_mode must be either 'required' or 'preferred'"
   }
 }

--- a/aws/elasticache/variables.tf
+++ b/aws/elasticache/variables.tf
@@ -116,6 +116,7 @@ variable "maxmemory_policy" {
   type        = string
   default     = null
   description = "Only effective, when NOT passing a custom parameter group name"
+
   validation {
     condition     = var.maxmemory_policy == null || contains(["volatile-lru", "allkeys-lru", "volatile-lfu", "allkeys-lfu", "volatile-random", "allkeys-random", "volatile-ttl", "noeviction"], var.maxmemory_policy)
     error_message = "maxmemory_policy must be one of volatile-lru, allkeys-lru, volatile-lfu, allkeys-lfu, volatile-random, allkeys-random, volatile-ttl, noeviction"

--- a/aws/stack/app/elasticache.tf
+++ b/aws/stack/app/elasticache.tf
@@ -29,4 +29,5 @@ module "elasticache" {
   cluster_mode               = var.elasticache_cluster_mode
   maxmemory_policy           = var.elasticache_maxmemory_policy == null ? (var.elasticache_cluster_mode ? "volatile-lru" : "noeviction") : var.elasticache_maxmemory_policy
   transit_encryption_enabled = var.elasticache_transit_encryption_enabled
+  transit_encryption_mode    = var.elasticache_transit_encryption_mode
 }

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -397,6 +397,17 @@ variable "rds_ca_cert_identifier" {
 # =============== ECS ================ #
 variable "health_check_path" { default = "/livez" }
 
+variable "elasticache_transit_encryption_mode" {
+  type        = string
+  default     = "required"
+  description = "when migrating from no encryption to encryption, this must be set to 'preferred', then apply changes, then set to 'required'"
+
+  validation {
+    condition     = contains(["required", "preferred"], var.elasticache_transit_encryption_mode)
+    error_message = "elasticache_transit_encryption_mode must be either 'required' or 'preferred'"
+  }
+}
+
 variable "enable_container_insights" {
   type    = bool
   default = null

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -403,7 +403,7 @@ variable "elasticache_transit_encryption_mode" {
   description = "when migrating from no encryption to encryption, this must be set to 'preferred', then apply changes, then set to 'required'"
 
   validation {
-    condition     = contains(["required", "preferred", null], var.elasticache_transit_encryption_mode)
+    condition     = var.elasticache_transit_encryption_mode == null || contains(["required", "preferred"], var.elasticache_transit_encryption_mode)
     error_message = "elasticache_transit_encryption_mode must be either 'required' or 'preferred'"
   }
 }

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -403,7 +403,7 @@ variable "elasticache_transit_encryption_mode" {
   description = "when migrating from no encryption to encryption, this must be set to 'preferred', then apply changes, then set to 'required'"
 
   validation {
-    condition     = contains(["required", "preferred"], var.elasticache_transit_encryption_mode)
+    condition     = contains(["required", "preferred", null], var.elasticache_transit_encryption_mode)
     error_message = "elasticache_transit_encryption_mode must be either 'required' or 'preferred'"
   }
 }

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -400,6 +400,7 @@ variable "health_check_path" { default = "/livez" }
 variable "elasticache_transit_encryption_mode" {
   type        = string
   default     = null
+  nullable    = true
   description = "when migrating from no encryption to encryption, this must be set to 'preferred', then apply changes, then set to 'required'"
 
   validation {

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -398,9 +398,9 @@ variable "rds_ca_cert_identifier" {
 variable "health_check_path" { default = "/livez" }
 
 variable "elasticache_transit_encryption_mode" {
-  type        = string
-  default     = null
-  nullable    = true
+  type    = string
+  default = null
+  # nullable    = true
   description = "when migrating from no encryption to encryption, this must be set to 'preferred', then apply changes, then set to 'required'"
 
   validation {

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -399,7 +399,7 @@ variable "health_check_path" { default = "/livez" }
 
 variable "elasticache_transit_encryption_mode" {
   type        = string
-  default     = "required"
+  default     = null
   description = "when migrating from no encryption to encryption, this must be set to 'preferred', then apply changes, then set to 'required'"
 
   validation {

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -398,13 +398,13 @@ variable "rds_ca_cert_identifier" {
 variable "health_check_path" { default = "/livez" }
 
 variable "elasticache_transit_encryption_mode" {
-  type    = string
-  default = null
-  # nullable    = true
+  type        = string
+  default     = null
+  nullable    = true
   description = "when migrating from no encryption to encryption, this must be set to 'preferred', then apply changes, then set to 'required'"
 
   validation {
-    condition     = var.elasticache_transit_encryption_mode == null || contains(["required", "preferred"], var.elasticache_transit_encryption_mode)
+    condition     = var.elasticache_transit_encryption_mode == null || var.elasticache_transit_encryption_mode == "required" || var.elasticache_transit_encryption_mode == "preferred"
     error_message = "elasticache_transit_encryption_mode must be either 'required' or 'preferred'"
   }
 }


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

Allow passing `transit_encryption_mode` through to the `stack` module.

#### Motivation

Required to updated Redis when using the stack module.
