### PR TITLE
Allow lambda access

### DIFF
--- a/aws/iam/iam-for-deploy-bot/main.tf
+++ b/aws/iam/iam-for-deploy-bot/main.tf
@@ -174,6 +174,7 @@ resource "aws_iam_policy" "deploy-bot-lambda-access" {
       {
         Effect = "Allow"
         Action = [
+          "lambda:AddPermission",
           "lambda:GetPolicy",
           "lambda:GetFunction",
           "lambda:ListFunctions",
@@ -189,7 +190,8 @@ resource "aws_iam_policy" "deploy-bot-lambda-access" {
           "lambda:UntagResource",
           "iam:ListRolePolicies",
           "iam:GetRolePolicy",
-          "iam:GetRole"
+          "iam:GetRole",
+          "iam:PassRole"
         ]
         Resource = "*"
       }

--- a/aws/iam/iam-for-deploy-bot/main.tf
+++ b/aws/iam/iam-for-deploy-bot/main.tf
@@ -163,6 +163,40 @@ resource "aws_iam_policy" "service-discovery-access" {
   })
 }
 
+resource "aws_iam_policy" "deploy-bot-lambda-access" {
+  name        = "DeployBot_LambdaAccess"
+  path        = "/"
+  description = "Allow Lambda access for deploy-bot"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "lambda:GetPolicy",
+          "lambda:GetFunction",
+          "lambda:ListFunctions",
+          "lambda:ListVersionsByFunction",
+          "lambda:GetFunctionConfiguration",
+          "lambda:GetFunctionCodeSigningConfig",
+          "lambda:UpdateFunctionCode",
+          "lambda:UpdateFunctionConfiguration",
+          "lambda:PublishVersion",
+          "lambda:CreateFunction",
+          "lambda:DeleteFunction",
+          "lambda:TagResource",
+          "lambda:UntagResource",
+          "iam:ListRolePolicies",
+          "iam:GetRolePolicy",
+          "iam:GetRole"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
 resource "aws_iam_group_policy_attachment" "deploy-bot-ecs-access" {
   group      = aws_iam_group.deploy-bot-deploy-access.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonECS_FullAccess"
@@ -191,4 +225,9 @@ resource "aws_iam_group_policy_attachment" "deploy-bot-s3-access" {
 resource "aws_iam_group_policy_attachment" "service-discovery-access" {
   group      = aws_iam_group.deploy-bot-deploy-access.name
   policy_arn = aws_iam_policy.service-discovery-access.arn
+}
+
+resource "aws_iam_group_policy_attachment" "deploy-bot-lambda-access" {
+  group      = aws_iam_group.deploy-bot-deploy-access.name
+  policy_arn = aws_iam_policy.deploy-bot-lambda-access.arn
 }


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

We provide lambda module but whenever you decide to use it there's not enough permissions on deploy-bot, let's fix that

#### Motivation

Allow access to manage lambdas for deploy-bot
