### PR TITLE
chore: move S3 policy for guest accounts into group (from inline)

### DIFF
--- a/aws/s3-shared/guest-iam.tf
+++ b/aws/s3-shared/guest-iam.tf
@@ -28,9 +28,9 @@ data "aws_iam_policy_document" "s3" {
   }
 }
 
-resource "aws_iam_user_policy" "s3" {
+resource "aws_iam_group_policy" "s3" {
   name   = "s3-access-for-${module.s3.bucket_name}"
-  user   = aws_iam_user.guest.name
+  group  = "guest-humans"
   policy = data.aws_iam_policy_document.s3.json
 }
 


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

No actual change. Just move the S3 access policy from a direct attachment into the group for guest accounts.

#### Motivation

ISO27001
