### PR TITLE
disallow destroying ecs service via terraform

### DIFF
--- a/aws/ecs-deploy/service/ecs_service.tf
+++ b/aws/ecs-deploy/service/ecs_service.tf
@@ -103,6 +103,12 @@ resource "aws_ecs_service" "main" {
     ignore_changes = [
       desired_count # We should not care about the desired count after the first deployment
     ]
+
+    #
+    # If set to true, the resource will be protected from destruction via Terraform.
+    # Destroying the resource will require doing so manually via the AWS console or CLI.
+    #
+    prevent_destroy = true
   }
 }
 


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

if you accidentally delete a service via terraform, it can take several hours for AWS to **actually** delete the service. There is nothing you can do during that period to re-launch a service with the same name.

#### Motivation

<!-- Why are you making this change? -->
