### PR TITLE
feat: AWS Aurora & Redshift Serverless

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,38 +7,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  azure:
-    strategy:
-      matrix:
-        module:
-          - blob-storage
-          - container-app
-          - container-registry
-          - database/postgres
-          - observability/alerts
-          - observability/monitors
-          - virtual-network
-      fail-fast: false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: opentofu/setup-opentofu@v1
+  # azure:
+  #   strategy:
+  #     matrix:
+  #       module:
+  #         - blob-storage
+  #         - container-app
+  #         - container-registry
+  #         - database/postgres
+  #         - observability/alerts
+  #         - observability/monitors
+  #         - virtual-network
+  #     fail-fast: false
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: opentofu/setup-opentofu@v1
 
-      - name: init
-        run: |
-          cd azure
-          cd ${{ matrix.module }}
-          tofu init
-      - name: validate
-        run: |
-          cd azure
-          cd ${{ matrix.module }}
-          tofu validate
-      - name: fmt -check
-        run: |
-          cd azure
-          cd ${{ matrix.module }}
-          tofu fmt -check
+  #     - name: init
+  #       run: |
+  #         cd azure
+  #         cd ${{ matrix.module }}
+  #         tofu init
+  #     - name: validate
+  #       run: |
+  #         cd azure
+  #         cd ${{ matrix.module }}
+  #         tofu validate
+  #     - name: fmt -check
+  #       run: |
+  #         cd azure
+  #         cd ${{ matrix.module }}
+  #         tofu fmt -check
 
   aws:
     strategy:

--- a/aws/aurora/README.md
+++ b/aws/aurora/README.md
@@ -1,0 +1,232 @@
+# Aurora PostgreSQL
+
+This module creates an Amazon Aurora PostgreSQL cluster with support for zero-ETL integration with Amazon Redshift.
+
+## Features
+
+- **Aurora PostgreSQL** cluster with configurable number of instances
+- **Zero-ETL Integration** support with logical replication parameters
+- **IAM Database Authentication** enabled with pre-configured groups and policies
+- **Enhanced Monitoring** with CloudWatch integration
+- **Performance Insights** enabled
+- **Encryption** at rest and in transit
+- **Backup and Snapshot** management
+- **Security Groups** with configurable access rules
+
+## Differences from RDS Module
+
+Aurora is a cloud-native database service that differs from traditional RDS:
+
+- **Cluster Architecture**: Aurora uses a cluster with multiple instances (writer/reader)
+- **Storage**: Aurora uses a distributed, fault-tolerant storage system
+- **Scaling**: Aurora can scale read capacity by adding reader instances
+- **Zero-ETL**: Aurora PostgreSQL supports zero-ETL integration with Redshift
+- **Performance**: Generally better performance than traditional RDS
+
+## Usage
+
+### Basic Usage
+
+```terraform
+module "aurora" {
+  source = "github.com/dbl-works/terraform//aws/aurora?ref=v2021.07.01"
+
+  project     = "myproject"
+  environment = "staging"
+  region      = "eu-central-1"
+
+  # Networking
+  vpc_id     = module.vpc.id
+  subnet_ids = module.vpc.subnet_private_ids
+
+  # Security
+  kms_key_arn = module.kms.key_arn
+  allow_from_security_groups = [
+    module.ecs.security_group_id
+  ]
+
+  # Credentials (stored in AWS Secrets Manager)
+  username = "root"
+  password = var.aurora_password
+}
+```
+
+### With Zero-ETL Integration Support
+
+```terraform
+module "aurora" {
+  source = "github.com/dbl-works/terraform//aws/aurora?ref=v2021.07.01"
+
+  project     = "myproject"
+  environment = "staging"
+  region      = "eu-central-1"
+
+  # Networking
+  vpc_id     = module.vpc.id
+  subnet_ids = module.vpc.subnet_private_ids
+
+  # Security
+  kms_key_arn = module.kms.key_arn
+  allow_from_security_groups = [
+    module.ecs.security_group_id
+  ]
+
+  # Credentials
+  username = "root"
+  password = var.aurora_password
+
+  # Zero-ETL Integration
+  enable_replication = true  # Enables logical replication for zero-ETL
+
+  # Aurora Configuration
+  instance_count = 2  # 1 writer + 1 reader
+  instance_class = "db.r6g.large"
+  engine_version = "16.4"
+}
+```
+
+### Using with Redshift Serverless
+
+```terraform
+module "aurora" {
+  source = "github.com/dbl-works/terraform//aws/aurora?ref=v2021.07.01"
+
+  # ... basic configuration ...
+  enable_replication = true
+}
+
+module "redshift_serverless" {
+  source = "github.com/dbl-works/terraform//aws/redshift/serverless?ref=v2021.07.01"
+
+  # ... basic configuration ...
+
+  # RDS Integration (automatically creates zero-ETL integration)
+  source_rds_arn               = module.aurora.cluster_arn  # Use cluster_arn!
+  source_rds_security_group_id = module.aurora.security_group_id
+}
+```
+
+## Variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| `project` | Project name | `string` | n/a | yes |
+| `environment` | Environment name | `string` | n/a | yes |
+| `vpc_id` | VPC ID where Aurora will be deployed | `string` | n/a | yes |
+| `subnet_ids` | List of subnet IDs for Aurora | `list(string)` | n/a | yes |
+| `kms_key_arn` | KMS key ARN for encryption | `string` | n/a | yes |
+| `username` | Master username | `string` | `"root"` | no |
+| `password` | Master password | `string` | n/a | yes |
+| `instance_count` | Number of Aurora instances | `number` | `1` | no |
+| `instance_class` | Instance class for Aurora instances | `string` | `"db.r6g.large"` | no |
+| `engine_version` | Aurora PostgreSQL engine version | `string` | `"16.4"` | no |
+| `enable_replication` | Enable logical replication for zero-ETL | `bool` | `false` | no |
+| `backup_retention_period` | Backup retention period in days | `number` | `7` | no |
+| `allow_from_cidr_blocks` | CIDR blocks allowed to connect | `list(string)` | `[]` | no |
+| `allow_from_security_groups` | Security groups allowed to connect | `list(string)` | `[]` | no |
+| `snapshot_identifier` | DB snapshot to create cluster from | `string` | `null` | no |
+| `delete_automated_backups` | Delete automated backups after cluster deletion | `bool` | `true` | no |
+
+## Outputs
+
+### Aurora-Specific Outputs
+
+| Name | Description |
+|------|-------------|
+| `cluster_arn` | Aurora cluster ARN (use for zero-ETL integration) |
+| `cluster_endpoint` | Aurora cluster writer endpoint |
+| `cluster_reader_endpoint` | Aurora cluster reader endpoint |
+| `cluster_identifier` | Aurora cluster identifier |
+| `cluster_members` | List of Aurora cluster members |
+| `cluster_resource_id` | Aurora cluster resource ID (for IAM auth) |
+| `security_group_id` | Aurora security group ID |
+
+### Compatibility Outputs
+
+These outputs maintain compatibility with the RDS module for easier migration:
+
+| Name | Description |
+|------|-------------|
+| `database_url` | Database endpoint (alias for cluster_endpoint) |
+| `database_arn` | Database ARN (alias for cluster_arn) |
+| `database_security_group_id` | Security group ID (alias for security_group_id) |
+
+### IAM Outputs
+
+| Name | Description |
+|------|-------------|
+| `iam_group_arns_db_connect` | Map of IAM group ARNs for database connections (admin, readonly) |
+| `iam_group_arn_view` | IAM group ARN for viewing Aurora clusters |
+
+## IAM Database Authentication
+
+The module creates IAM groups for database access:
+
+- **Admin group**: `{name}-aurora-db-connect-admin` - Full database access
+- **Readonly group**: `{name}-aurora-db-connect-readonly` - Read-only database access
+- **View group**: `{name}-aurora-view` - Permission to list/describe clusters
+
+Add users to these groups to grant database access via IAM authentication.
+
+## Zero-ETL Integration
+
+To enable zero-ETL integration with Amazon Redshift:
+
+1. **Set `enable_replication = true`** in your Aurora module
+2. **Use `cluster_arn` output** as `source_rds_arn` in Redshift Serverless module
+3. **Aurora version** must be 16.4+ for PostgreSQL
+
+The Redshift Serverless module will automatically create the zero-ETL integration when you provide the Aurora cluster ARN.
+
+The module automatically configures the required parameters:
+
+- `rds.logical_replication = 1`
+- `aurora.enhanced_logical_replication = 1`
+- `aurora.logical_replication_backup = 0`
+- `aurora.logical_replication_globaldb = 0`
+
+## Migration from RDS Module
+
+Aurora module provides compatibility outputs to ease migration:
+
+```terraform
+# Old RDS usage
+module "rds" {
+  source = "github.com/dbl-works/terraform//aws/rds?ref=v2021.07.01"
+  # ... configuration ...
+}
+
+# References work the same
+resource "something" {
+  database_url = module.rds.database_url
+  security_group = module.rds.database_security_group_id
+}
+
+# New Aurora usage
+module "aurora" {
+  source = "github.com/dbl-works/terraform//aws/aurora?ref=v2021.07.01"
+  # ... configuration ...
+}
+
+# Same references still work
+resource "something" {
+  database_url = module.aurora.database_url        # Points to cluster_endpoint
+  security_group = module.aurora.database_security_group_id  # Points to security_group_id
+}
+```
+
+## Important Notes
+
+- **Multi-AZ**: Aurora is inherently Multi-AZ, no configuration needed
+- **Storage**: Aurora storage automatically scales, no allocated_storage parameter
+- **Instances**: Reader instances can be added/removed for read scaling
+- **Backups**: Aurora supports point-in-time recovery automatically
+- **Zero-ETL**: Only supported with Aurora PostgreSQL 16.4+
+
+## Best Practices
+
+1. **Use at least 2 instances** for production (1 writer + 1 reader)
+2. **Enable replication** only if you plan to use zero-ETL integration
+3. **Use r6g instance types** for best performance/cost ratio
+4. **Keep engine_version updated** for security and features
+5. **Use proper security groups** instead of CIDR blocks when possible

--- a/aws/aurora/README.md
+++ b/aws/aurora/README.md
@@ -134,22 +134,12 @@ module "redshift_serverless" {
 | Name | Description |
 |------|-------------|
 | `cluster_arn` | Aurora cluster ARN (use for zero-ETL integration) |
-| `cluster_endpoint` | Aurora cluster writer endpoint |
+| `cluster_writer_endpoint` | Aurora cluster writer endpoint |
 | `cluster_reader_endpoint` | Aurora cluster reader endpoint |
 | `cluster_identifier` | Aurora cluster identifier |
 | `cluster_members` | List of Aurora cluster members |
 | `cluster_resource_id` | Aurora cluster resource ID (for IAM auth) |
 | `security_group_id` | Aurora security group ID |
-
-### Compatibility Outputs
-
-These outputs maintain compatibility with the RDS module for easier migration:
-
-| Name | Description |
-|------|-------------|
-| `database_url` | Database endpoint (alias for cluster_endpoint) |
-| `database_arn` | Database ARN (alias for cluster_arn) |
-| `database_security_group_id` | Security group ID (alias for security_group_id) |
 
 ### IAM Outputs
 

--- a/aws/aurora/iam.tf
+++ b/aws/aurora/iam.tf
@@ -1,0 +1,130 @@
+# Aurora Enhanced Monitoring requires a specific role + KMS key to operate
+resource "aws_iam_role" "rds-enhanced-monitoring" {
+  name               = "aurora-enhanced-monitoring-${local.name}"
+  assume_role_policy = data.aws_iam_policy_document.rds_enhanced_monitoring.json
+
+  tags = {
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
+  role       = aws_iam_role.rds-enhanced-monitoring.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
+data "aws_iam_policy_document" "rds_enhanced_monitoring" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["monitoring.rds.amazonaws.com"]
+    }
+  }
+}
+
+# Database access IAM resources
+data "aws_caller_identity" "current" {}
+
+locals {
+  db_roles = [
+    "admin",
+    "readonly",
+  ]
+  account_id = data.aws_caller_identity.current.account_id
+}
+
+# IAM groups for database connections
+resource "aws_iam_group" "aurora-db-connect" {
+  for_each = toset(local.db_roles)
+  name     = "${local.name}-aurora-db-connect-${each.key}"
+}
+
+resource "aws_iam_policy" "aurora-db-connect" {
+  for_each    = toset(local.db_roles)
+  name        = "${local.name}-aurora-db-connect-${each.key}"
+  path        = "/"
+  description = "Allow connecting as ${each.key} to ${local.name} Aurora cluster (${var.region}) using IAM roles"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "rds-db:connect"
+        ]
+        Resource = [
+          "arn:aws:rds-db:${var.region}:${local.account_id}:dbuser:${aws_rds_cluster.main.cluster_resource_id}/${var.project}_${var.environment}_${each.key}"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "iam:ListPolicies"
+        ]
+        Resource = [
+          "arn:aws:iam::${local.account_id}:policy/${local.name}-aurora-db-connect-*",
+          "arn:aws:iam::${local.account_id}:policy/${local.name}-aurora-view"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_group_policy_attachment" "aurora-db-connect" {
+  for_each   = toset(local.db_roles)
+  group      = aws_iam_group.aurora-db-connect[each.key].name
+  policy_arn = aws_iam_policy.aurora-db-connect[each.key].arn
+}
+
+# Grant access to list and describe Aurora clusters
+resource "aws_iam_group" "aurora-view" {
+  name = "${local.name}-aurora-view"
+}
+
+resource "aws_iam_policy" "aurora-view" {
+  name        = "${local.name}-aurora-view"
+  path        = "/"
+  description = "Allow viewing Aurora clusters for ${local.name}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "rds:Describe*",
+          "rds:Get*",
+          "rds:List*"
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/Project"     = var.project
+            "aws:ResourceTag/Environment" = var.environment
+          }
+        }
+        Resource = ["*"]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "rds:DescribeDBClusters",
+          "rds:DescribeDBInstances"
+        ]
+        Resource = ["*"]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_group_policy_attachment" "aurora-view" {
+  group      = aws_iam_group.aurora-view.name
+  policy_arn = aws_iam_policy.aurora-view.arn
+}

--- a/aws/aurora/main.tf
+++ b/aws/aurora/main.tf
@@ -35,11 +35,7 @@ resource "aws_rds_cluster" "main" {
     "postgresql"
   ]
 
-  # Enable IAM authentication
   iam_database_authentication_enabled = true
-
-  # Zero-ETL integration support
-  manage_master_user_password = true
 
   dynamic "serverlessv2_scaling_configuration" {
     for_each = var.instance_class == "db.serverless" ? [1] : []

--- a/aws/aurora/main.tf
+++ b/aws/aurora/main.tf
@@ -1,0 +1,84 @@
+locals {
+  major_engine_version      = split(".", var.engine_version)[0]
+  final_snapshot_identifier = "final-snapshot-${var.project}-${var.environment}"
+  name                      = var.name != null ? var.name : "${var.project}-${var.environment}${var.regional ? "-${var.region}" : ""}"
+}
+
+# Aurora PostgreSQL Cluster
+resource "aws_rds_cluster" "main" {
+  cluster_identifier              = var.identifier == null ? local.name : var.identifier
+  engine                         = "aurora-postgresql"
+  engine_version                 = var.engine_version
+  database_name                  = replace("${var.project}_${var.environment}", "/[^0-9A-Za-z_]/", "_")
+  master_username                = var.username
+  master_password                = var.password
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.main.name
+  db_subnet_group_name           = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [
+    aws_security_group.db.id,
+  ]
+
+  backup_retention_period         = var.backup_retention_period
+  preferred_backup_window         = "03:00-04:00"
+  preferred_maintenance_window    = "sun:04:00-sun:05:00"
+  storage_encrypted              = true
+  kms_key_id                     = var.kms_key_arn
+  deletion_protection            = true
+  skip_final_snapshot           = var.skip_final_snapshot
+  final_snapshot_identifier     = var.final_snapshot_identifier == null ? local.final_snapshot_identifier : var.final_snapshot_identifier
+  apply_immediately              = true
+  snapshot_identifier            = var.snapshot_identifier
+  delete_automated_backups       = var.delete_automated_backups
+
+  enabled_cloudwatch_logs_exports = [
+    "postgresql"
+  ]
+
+  # Enable IAM authentication
+  iam_database_authentication_enabled = true
+
+  # Zero-ETL integration support
+  manage_master_user_password = false
+
+  tags = {
+    Name        = local.name
+    Project     = var.project
+    Environment = var.environment
+  }
+
+  lifecycle {
+    ignore_changes = [
+      engine_version, # AWS will auto-update minor version changes
+      database_name,  # Consistent with RDS module's db_name
+      master_username,
+      master_password,
+      snapshot_identifier,
+    ]
+  }
+}
+
+# Aurora PostgreSQL Cluster Instances
+resource "aws_rds_cluster_instance" "cluster_instances" {
+  count = var.instance_count
+
+  identifier              = "${aws_rds_cluster.main.cluster_identifier}-${count.index}"
+  cluster_identifier      = aws_rds_cluster.main.id
+  instance_class          = var.instance_class
+  engine                  = aws_rds_cluster.main.engine
+  engine_version          = aws_rds_cluster.main.engine_version
+  db_parameter_group_name = aws_db_parameter_group.instance.name
+
+  performance_insights_enabled    = true
+  performance_insights_kms_key_id = var.kms_key_arn
+  monitoring_interval             = 5
+  monitoring_role_arn             = aws_iam_role.rds-enhanced-monitoring.arn
+  apply_immediately              = true
+
+  ca_cert_identifier = var.ca_cert_identifier
+
+  tags = {
+    Name        = "${local.name}-${count.index}"
+    Project     = var.project
+    Environment = var.environment
+  }
+}

--- a/aws/aurora/main.tf
+++ b/aws/aurora/main.tf
@@ -39,7 +39,7 @@ resource "aws_rds_cluster" "main" {
   iam_database_authentication_enabled = true
 
   # Zero-ETL integration support
-  manage_master_user_password = false
+  manage_master_user_password = true
 
   dynamic "serverlessv2_scaling_configuration" {
     for_each = var.instance_class == "db.serverless" ? [1] : []

--- a/aws/aurora/outputs.tf
+++ b/aws/aurora/outputs.tf
@@ -39,15 +39,9 @@ output "security_group_id" {
   description = "Security group ID for Aurora cluster"
 }
 
-# Compatibility outputs (for easier migration from RDS module)
 output "database_url" {
   value = aws_rds_cluster.main.endpoint
   description = "Database endpoint URL (alias for cluster_endpoint)"
-}
-
-output "database_address" {
-  value = aws_rds_cluster.main.endpoint
-  description = "Database address (alias for cluster_endpoint)"
 }
 
 output "database_arn" {

--- a/aws/aurora/outputs.tf
+++ b/aws/aurora/outputs.tf
@@ -1,0 +1,77 @@
+# Aurora Cluster outputs
+output "cluster_arn" {
+  value = aws_rds_cluster.main.arn
+  description = "Aurora cluster ARN (use this for zero-ETL integration source_rds_arn)"
+}
+
+output "cluster_endpoint" {
+  value = aws_rds_cluster.main.endpoint
+  description = "Aurora cluster writer endpoint"
+}
+
+output "cluster_reader_endpoint" {
+  value = aws_rds_cluster.main.reader_endpoint
+  description = "Aurora cluster reader endpoint"
+}
+
+output "cluster_identifier" {
+  value = aws_rds_cluster.main.cluster_identifier
+  description = "Aurora cluster identifier"
+}
+
+output "cluster_members" {
+  value = aws_rds_cluster.main.cluster_members
+  description = "List of Aurora cluster members"
+}
+
+output "cluster_resource_id" {
+  value = aws_rds_cluster.main.cluster_resource_id
+  description = "Aurora cluster resource ID (used for IAM authentication)"
+}
+
+output "database_name" {
+  value = aws_rds_cluster.main.database_name
+  description = "Database name"
+}
+
+output "security_group_id" {
+  value = aws_security_group.db.id
+  description = "Security group ID for Aurora cluster"
+}
+
+# Compatibility outputs (for easier migration from RDS module)
+output "database_url" {
+  value = aws_rds_cluster.main.endpoint
+  description = "Database endpoint URL (alias for cluster_endpoint)"
+}
+
+output "database_address" {
+  value = aws_rds_cluster.main.endpoint
+  description = "Database address (alias for cluster_endpoint)"
+}
+
+output "database_arn" {
+  value = aws_rds_cluster.main.arn
+  description = "Database ARN (alias for cluster_arn)"
+}
+
+output "database_identifier" {
+  value = aws_rds_cluster.main.cluster_identifier
+  description = "Database identifier (alias for cluster_identifier)"
+}
+
+output "database_security_group_id" {
+  value = aws_security_group.db.id
+  description = "Database security group ID (alias for security_group_id)"
+}
+
+# IAM outputs
+output "iam_group_arns_db_connect" {
+  value = { for role, group in aws_iam_group.aurora-db-connect : role => group.arn }
+  description = "IAM group ARNs for database connections"
+}
+
+output "iam_group_arn_view" {
+  value = aws_iam_group.aurora-view.arn
+  description = "IAM group ARN for viewing Aurora clusters"
+}

--- a/aws/aurora/outputs.tf
+++ b/aws/aurora/outputs.tf
@@ -4,7 +4,7 @@ output "cluster_arn" {
   description = "Aurora cluster ARN (use this for zero-ETL integration source_rds_arn)"
 }
 
-output "cluster_endpoint" {
+output "cluster_writer_endpoint" {
   value = aws_rds_cluster.main.endpoint
   description = "Aurora cluster writer endpoint"
 }
@@ -37,11 +37,6 @@ output "database_name" {
 output "security_group_id" {
   value = aws_security_group.db.id
   description = "Security group ID for Aurora cluster"
-}
-
-output "database_url" {
-  value = aws_rds_cluster.main.endpoint
-  description = "Database endpoint URL (alias for cluster_endpoint)"
 }
 
 output "database_arn" {

--- a/aws/aurora/parameter-groups.tf
+++ b/aws/aurora/parameter-groups.tf
@@ -1,0 +1,120 @@
+# Aurora Cluster Parameter Group
+resource "aws_rds_cluster_parameter_group" "main" {
+  name   = "${local.name}-aurora-postgres${local.major_engine_version}"
+  family = "aurora-postgresql${local.major_engine_version}"
+
+  parameter {
+    name  = "log_statement"
+    value = "none"
+  }
+
+  parameter {
+    name  = "log_min_duration_statement"
+    value = var.log_min_duration_statement
+  }
+
+  parameter {
+    name  = "log_min_error_statement"
+    value = var.log_min_error_statement
+  }
+
+  # Only set logical replication parameters when explicitly enabled
+  dynamic "parameter" {
+    for_each = var.enable_replication ? [1] : []
+    content {
+      name         = "rds.logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    }
+  }
+
+  # Required for zero-ETL integration - only when replication is enabled
+  dynamic "parameter" {
+    for_each = var.enable_replication ? [1] : []
+    content {
+      name         = "aurora.enhanced_logical_replication"
+      value        = "1"
+      apply_method = "pending-reboot"
+    }
+  }
+
+  # IMPORTANT: Explicitly disable Global Database replication features
+  # These MUST be set to 0 when using logical replication for zero-ETL
+  # to prevent conflicts with Global Database replication
+  dynamic "parameter" {
+    for_each = var.enable_replication ? [1] : []
+    content {
+      name         = "aurora.logical_replication_backup"
+      value        = "0"
+      apply_method = "pending-reboot"
+    }
+  }
+
+  dynamic "parameter" {
+    for_each = var.enable_replication ? [1] : []
+    content {
+      name         = "aurora.logical_replication_globaldb"
+      value        = "0"
+      apply_method = "pending-reboot"
+    }
+  }
+
+  # Additional parameters required for logical replication to work properly
+  # According to AWS docs, these need to be adjusted when enabling logical replication
+  dynamic "parameter" {
+    for_each = var.enable_replication ? [1] : []
+    content {
+      name         = "max_replication_slots"
+      value        = "10"  # AWS recommends at least equal to planned publications + subscriptions
+      apply_method = "pending-reboot"
+    }
+  }
+
+  dynamic "parameter" {
+    for_each = var.enable_replication ? [1] : []
+    content {
+      name         = "max_wal_senders"
+      value        = "10"  # Should be at least equal to active replication slots
+      apply_method = "pending-reboot"
+    }
+  }
+
+  dynamic "parameter" {
+    for_each = var.enable_replication ? [1] : []
+    content {
+      name         = "max_logical_replication_workers"
+      value        = "4"  # Default is typically 4
+      apply_method = "pending-reboot"
+    }
+  }
+
+  # Note: aurora.logical_replication_backup and aurora.logical_replication_globaldb
+  # should NOT be set when using logical replication for zero-ETL as they are for
+  # Global Database replication and can cause conflicts.
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name        = "${local.name}-aurora-cluster"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+# Aurora Instance Parameter Group
+resource "aws_db_parameter_group" "instance" {
+  name   = "${local.name}-aurora-instance-postgres${local.major_engine_version}"
+  family = "aurora-postgresql${local.major_engine_version}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name        = "${local.name}-aurora-instance"
+    Project     = var.project
+    Environment = var.environment
+  }
+}

--- a/aws/aurora/security-group.tf
+++ b/aws/aurora/security-group.tf
@@ -1,0 +1,36 @@
+resource "aws_security_group" "db" {
+  name   = "${local.name}-aurora"
+  vpc_id = var.vpc_id
+
+  tags = {
+    Name        = "${local.name}-aurora"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+resource "aws_security_group_rule" "db-from-cidr-blocks" {
+  count = length(var.allow_from_cidr_blocks)
+
+  type              = "ingress"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  security_group_id = aws_security_group.db.id
+  cidr_blocks = [
+    var.allow_from_cidr_blocks[count.index],
+  ]
+  description = "From CIDR Block: ${var.allow_from_cidr_blocks[count.index]}"
+}
+
+resource "aws_security_group_rule" "db-from-security-groups" {
+  count = length(var.allow_from_security_groups)
+
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.db.id
+  source_security_group_id = var.allow_from_security_groups[count.index]
+  description              = "From security group: ${var.allow_from_security_groups[count.index]}"
+}

--- a/aws/aurora/subnet-group.tf
+++ b/aws/aurora/subnet-group.tf
@@ -1,0 +1,14 @@
+resource "aws_db_subnet_group" "main" {
+  name       = var.subnet_group_name == null ? local.name : var.subnet_group_name
+  subnet_ids = var.subnet_ids
+
+  tags = {
+    Name        = var.subnet_group_name == null ? local.name : var.subnet_group_name
+    Project     = var.project
+    Environment = var.environment
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/aws/aurora/variables.tf
+++ b/aws/aurora/variables.tf
@@ -43,10 +43,10 @@ variable "instance_count" {
 }
 
 variable "engine_version" {
-  default     = "16.4"
+  default     = "17.4"
   type        = string
   nullable    = false
-  description = "Aurora PostgreSQL engine version (e.g., '16.4', '15.4')"
+  description = "Aurora PostgreSQL engine version (e.g., '16.4', '17.4')"
 }
 
 # Credentials for the root Aurora user

--- a/aws/aurora/variables.tf
+++ b/aws/aurora/variables.tf
@@ -1,0 +1,123 @@
+variable "vpc_id" {}
+variable "subnet_ids" {}
+variable "kms_key_arn" {}
+variable "project" {}
+variable "environment" {}
+variable "region" {
+  type    = string
+  default = "eu-central-1"
+}
+
+variable "ca_cert_identifier" {
+  default = "rds-ca-ecc384-g1"
+  type    = string
+}
+
+variable "backup_retention_period" {
+  default = 7
+  type    = number
+}
+
+variable "instance_class" {
+  default = "db.r6g.large"
+  type    = string
+  description = "Instance class for Aurora cluster instances"
+}
+
+variable "instance_count" {
+  type        = number
+  default     = 1
+  description = "Number of Aurora cluster instances"
+}
+
+variable "engine_version" {
+  default  = "16.4"
+  type     = string
+  nullable = false
+  description = "Aurora PostgreSQL engine version (e.g., '16.4', '15.4')"
+}
+
+# Credentials for the root Aurora user
+# Only to be used in initial setup, never by applications
+variable "username" {
+  default   = "root"
+  sensitive = true
+}
+variable "password" {
+  sensitive = true
+}
+
+# Allow traffic from CIDR blocks
+variable "allow_from_cidr_blocks" { default = [] }
+
+variable "allow_from_security_groups" {
+  description = "Security groups which Aurora allow traffics from"
+  default     = []
+}
+
+# A custom name overrides the default {project}-{environment} convention
+variable "name" {
+  type        = string
+  description = "Custom name for resources. Must be unique per account if deploying to multiple regions."
+  default     = null
+}
+
+variable "enable_replication" {
+  type        = bool
+  description = "Enables logical replication for zero-ETL integration."
+  default     = false
+}
+
+variable "subnet_group_name" {
+  type    = string
+  default = null
+}
+
+variable "skip_final_snapshot" {
+  type    = bool
+  default = false
+}
+
+variable "final_snapshot_identifier" {
+  type    = string
+  default = null
+}
+
+variable "identifier" {
+  type    = string
+  default = null
+}
+
+variable "regional" {
+  default = false
+  type    = bool
+}
+
+variable "snapshot_identifier" {
+  type    = string
+  default = null
+  description = "DB snapshot to create Aurora cluster from"
+}
+
+variable "delete_automated_backups" {
+  type    = bool
+  default = true
+  description = "Whether to delete automated backups immediately after the DB cluster is deleted"
+}
+
+variable "log_min_duration_statement" {
+  type        = number
+  default     = -1
+  description = "Used to log SQL statements that run longer than a specified duration of time (in ms)."
+}
+
+variable "log_min_error_statement" {
+  type        = string
+  default     = "panic"
+  description = "Controls which SQL statements that cause an error condition are recorded in the server log."
+
+  validation {
+    condition     = contains(["debug5", "debug4", "debug3", "debug2", "debug1", "info", "notice", "warning", "error", "log", "fatal", "panic"], var.log_min_error_statement)
+    error_message = "The valid values are [debug5, debug4, debug3, debug2, debug1, info, notice, warning, error, log, fatal, panic]"
+  }
+}

--- a/aws/aurora/variables.tf
+++ b/aws/aurora/variables.tf
@@ -19,21 +19,21 @@ variable "backup_retention_period" {
 }
 
 variable "instance_class" {
-  default = "db.r6g.large"
-  type    = string
+  default     = "db.r6g.large"
+  type        = string
   description = "Instance class for Aurora cluster instances"
 }
 
 variable "instance_count" {
   type        = number
   default     = 1
-  description = "Number of Aurora cluster instances"
+  description = "Number of Nodes in the Aurora cluster. Use 2 for separate writer/reader nodes."
 }
 
 variable "engine_version" {
-  default  = "16.4"
-  type     = string
-  nullable = false
+  default     = "16.4"
+  type        = string
+  nullable    = false
   description = "Aurora PostgreSQL engine version (e.g., '16.4', '15.4')"
 }
 
@@ -94,14 +94,14 @@ variable "regional" {
 }
 
 variable "snapshot_identifier" {
-  type    = string
-  default = null
+  type        = string
+  default     = null
   description = "DB snapshot to create Aurora cluster from"
 }
 
 variable "delete_automated_backups" {
-  type    = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Whether to delete automated backups immediately after the DB cluster is deleted"
 }
 

--- a/aws/aurora/variables.tf
+++ b/aws/aurora/variables.tf
@@ -19,9 +19,21 @@ variable "backup_retention_period" {
 }
 
 variable "instance_class" {
-  default     = "db.r6g.large"
+  default     = "db.serverless"
   type        = string
-  description = "Instance class for Aurora cluster instances"
+  description = "Instance class for Aurora cluster instances, e.g. 'db.serverless', 'db.t3.medium', 'db.r5.large'."
+}
+
+variable "max_capacity" {
+  type        = number
+  default     = 2.0
+  description = "Maximum capacity for serverless instances (e.g., 1.0, 1.5, 2.0, 2.5, etc.). Only used if instance_class is 'db.serverless'."
+}
+
+variable "seconds_until_auto_pause" {
+  type        = number
+  default     = 300
+  description = "Time in seconds until serverless instances automatically pause (from 5 minutes to 24 hours). Only used if instance_class is 'db.serverless'."
 }
 
 variable "instance_count" {

--- a/aws/aurora/versions.tf
+++ b/aws/aurora/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/aws/aurora/versions.tf
+++ b/aws/aurora/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 6.0"
     }
   }
   required_version = ">= 1.0"

--- a/aws/iam/iam-policy-for-redshift-serverless/taggable-resources/README.md
+++ b/aws/iam/iam-policy-for-redshift-serverless/taggable-resources/README.md
@@ -10,7 +10,7 @@ Either project_name and project_tag needs to be present.
 
 ```terraform
 module "iam_redshift_serverless_taggable_resources" {
-  source = "github.com/dbl-works/terraform//iam/iam-policy-for-redshift-serverless/taggable-resources?ref=v2025.05.18"
+  source = "github.com/dbl-works/terraform//aws/iam/iam-policy-for-redshift-serverless/taggable-resources?ref=v2025.05.18"
 
   region       = "eu-central-1"
   environment  = "staging"

--- a/aws/iam/iam-policy-for-redshift-serverless/taggable-resources/README.md
+++ b/aws/iam/iam-policy-for-redshift-serverless/taggable-resources/README.md
@@ -1,0 +1,40 @@
+# Terraform Module: IAM Policy for Redshift Serverless - Taggable Resources
+
+Tag-based IAM policy for Redshift Serverless access control.
+Either project_name and project_tag needs to be present.
+
+- When `project_name` is present, access will be given to the resources with `Project` tags equals to the `project_name` value
+- When `project_tag` is present, access will be given to the resources with `Project` tags similar to that principal project tag
+
+## Usage
+
+```terraform
+module "iam_redshift_serverless_taggable_resources" {
+  source = "github.com/dbl-works/terraform//iam/iam-policy-for-redshift-serverless/taggable-resources?ref=v2025.05.18"
+
+  region       = "eu-central-1"
+  environment  = "staging"
+
+  # Optional
+  project_name = "facebook"
+  project_tag  = "staging-developer-access-projects"
+}
+
+output "policy_json" {
+  value = module.iam_redshift_serverless_taggable_resources.policy_json
+}
+```
+
+## Permissions Granted
+
+This module grants the following permissions to Redshift Serverless resources with matching Project/Environment tags:
+
+- `redshift-serverless:GetCredentials` - Get temporary database credentials for IAM authentication
+- `redshift-serverless:GetWorkgroup` - View workgroup details
+- `redshift-serverless:ListWorkgroups` - List available workgroups
+- `redshift-serverless:GetNamespace` - View namespace details
+- `redshift-serverless:ListNamespaces` - List available namespaces
+- `redshift-serverless:GetEndpointAccess` - View endpoint access details
+- `redshift-serverless:ListEndpointAccess` - List available endpoint accesses
+
+These permissions allow users to connect to Redshift Serverless via bastion hosts using IAM authentication.

--- a/aws/iam/iam-policy-for-redshift-serverless/taggable-resources/outputs.tf
+++ b/aws/iam/iam-policy-for-redshift-serverless/taggable-resources/outputs.tf
@@ -1,0 +1,3 @@
+output "policy_json" {
+  value = data.aws_iam_policy_document.redshift_serverless_policy.json
+}

--- a/aws/iam/iam-policy-for-redshift-serverless/taggable-resources/redshift-policy.tf
+++ b/aws/iam/iam-policy-for-redshift-serverless/taggable-resources/redshift-policy.tf
@@ -1,0 +1,58 @@
+locals {
+  # must be alpha-numeric
+  sid_name = replace(
+    title(var.project_name != null ? "${title(var.environment)}-${title(var.project_name)}" : title(var.environment)),
+    "/[^0-9A-Za-z]/",
+    ""
+  )
+}
+
+data "aws_iam_policy_document" "redshift_serverless_policy" {
+  statement {
+    sid = "AllowRedshiftServerlessGetCredentials${local.sid_name}"
+    actions = [
+      "redshift-serverless:GetCredentials"
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/Environment"
+      values   = [var.environment]
+    }
+
+    condition {
+      # Using StringLike here because currently tag cannot take multivalue
+      # We can only create a custom multivalue structure in the single value
+      # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html
+      test     = var.project_name != null ? "StringEquals" : "StringLike"
+      variable = "aws:ResourceTag/Project"
+      values   = var.project_name != null ? [var.project_name] : ["&{aws:PrincipalTag/${var.project_tag}}"]
+    }
+  }
+
+  statement {
+    sid = "AllowRedshiftServerlessListDescribe${local.sid_name}"
+    actions = [
+      "redshift-serverless:GetWorkgroup",
+      "redshift-serverless:ListWorkgroups",
+      "redshift-serverless:GetNamespace",
+      "redshift-serverless:ListNamespaces",
+      "redshift-serverless:GetEndpointAccess",
+      "redshift-serverless:ListEndpointAccess"
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/Environment"
+      values   = [var.environment]
+    }
+
+    condition {
+      test     = var.project_name != null ? "StringEquals" : "StringLike"
+      variable = "aws:ResourceTag/Project"
+      values   = var.project_name != null ? [var.project_name] : ["&{aws:PrincipalTag/${var.project_tag}}"]
+    }
+  }
+}

--- a/aws/iam/iam-policy-for-redshift-serverless/taggable-resources/variables.tf
+++ b/aws/iam/iam-policy-for-redshift-serverless/taggable-resources/variables.tf
@@ -1,0 +1,21 @@
+variable "region" {
+  type        = string
+  description = "The AWS region where resources are deployed"
+}
+
+variable "environment" {
+  type        = string
+  description = "The environment name (e.g., staging, production)"
+}
+
+variable "project_name" {
+  type        = string
+  description = "The project name for specific project access"
+  default     = null
+}
+
+variable "project_tag" {
+  type        = string
+  description = "The principal tag key for project-based access"
+  default     = "staging-developer-access-projects"
+}

--- a/aws/iam/iam-policy-for-redshift-serverless/taggable-resources/versions.tf
+++ b/aws/iam/iam-policy-for-redshift-serverless/taggable-resources/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/aws/nat/README.md
+++ b/aws/nat/README.md
@@ -1,8 +1,6 @@
 # Terraform Module: NAT
 
-A reopsitory for setting up a network address translation (NAT).
-
-
+A repository for setting up network address translation (NAT).
 
 ## Usage
 
@@ -25,7 +23,16 @@ module "nat" {
 
 `public_ips` is a list of Elastic IPs that have to belong to the same AWS account that hosts the NAT.
 
+## How it Works
 
+- Creates one NAT Gateway per Elastic IP provided
+- Creates one route table per private subnet
+- If you have more private subnets than NAT Gateways, the module cycles through available NAT Gateways
+  - Example: 3 private subnets with 2 NAT Gateways means the 3rd subnet uses the 1st NAT Gateway
+
+## Compatibility
+
+This module supports dynamic subnet creation. The route table associations use indices as keys to avoid Terraform errors when creating new subnets.
 
 ## Outputs
 * `aws_route_table_ids` for VPC-Peering

--- a/aws/nat/nat.tf
+++ b/aws/nat/nat.tf
@@ -28,7 +28,7 @@ resource "aws_route" "main" {
 
 # Create route tables so elastic IPs are used for outgoing traffic
 resource "aws_route_table" "main" {
-  count  = length(var.subnet_public_ids)
+  count  = length(var.subnet_private_ids)
   vpc_id = var.vpc_id
 
   tags = {
@@ -41,8 +41,8 @@ resource "aws_route_table" "main" {
 # route tables for private subnets, e.g. if we want VPC peering between stacks without NATs
 # running the web process in a public subnet
 resource "aws_route_table_association" "main" {
-  for_each  = { for idx, subnet in var.subnet_private_ids : subnet => idx }
-  subnet_id = each.key
+  for_each  = { for idx, subnet in var.subnet_private_ids : tostring(idx) => subnet }
+  subnet_id = each.value
 
-  route_table_id = aws_route_table.main[each.value].id
+  route_table_id = aws_route_table.main[tonumber(each.key)].id
 }

--- a/aws/rds/outputs.tf
+++ b/aws/rds/outputs.tf
@@ -18,4 +18,3 @@ output "database_identifier" {
 output "database_security_group_id" {
   value = aws_security_group.db.id
 }
-

--- a/aws/redshift/serverless/README.md
+++ b/aws/redshift/serverless/README.md
@@ -46,10 +46,10 @@ module "redshift_serverless" {
 
 ### Connection URL Setup
 
-After deploying this module, Terraform will output a complete connection URL. Copy this URL to your app secrets:
+After deploying this module, Terraform will output connection URLs. For Ruby applications using the `pg` gem, use the PostgreSQL-compatible connection URL:
 
 ```bash
-# 1. Get the connection URL from Terraform output (it's marked as sensitive)
+# 1. Get the PostgreSQL-compatible connection URL from Terraform output (it's marked as sensitive)
 terraform output -raw connection_url
 
 # 2. Add it to your app secrets
@@ -57,6 +57,8 @@ aws secretsmanager put-secret-value \
   --secret-id "myproject/app/staging" \
   --secret-string '{"REDSHIFT_CONNECTION_URL":"postgresql://admin:password@endpoint:5439/database"}'
 ```
+
+**Note**: Redshift Serverless is PostgreSQL-compatible, so the `postgresql://` connection string format works with the Ruby `pg` gem and other PostgreSQL drivers. For native Redshift JDBC drivers, use `terraform output jdbc_url` instead.
 
 ### ECS Deployment Configuration
 
@@ -91,7 +93,8 @@ connection = PG.connect(ENV["REDSHIFT_CONNECTION_URL"])
 - `endpoint`: Redshift Serverless endpoint for connections
 - `database_name`: Name of the database
 - `admin_username`: Admin username for password authentication
-- `connection_url`: Complete PostgreSQL connection URL (copy this to your app secrets)
+- `connection_url`: PostgreSQL-compatible connection URL (copy this to your app secrets for Ruby pg gem)
+- `jdbc_url`: JDBC URL for native Redshift drivers
 
 ## Implementation Plan
 

--- a/aws/redshift/serverless/README.md
+++ b/aws/redshift/serverless/README.md
@@ -26,6 +26,8 @@ RDS zero-ETL integration is **only supported** for:
 
 Set `create_rds_integration = true` only if your RDS instance supports zero-ETL.
 
+**For Aurora clusters**: Use the **cluster ARN** (from `aws_rds_cluster`), not the instance ARN (from `aws_rds_cluster_instance`). Aurora creates both a cluster and instances, but the zero-ETL integration requires the cluster ARN.
+
 ### Password Requirements
 
 The Redshift admin password must meet AWS requirements:
@@ -67,7 +69,7 @@ module "redshift_serverless" {
 
   # RDS Integration (optional - only for Aurora MySQL/PostgreSQL or RDS MySQL)
   create_rds_integration           = false  # Set to true if your RDS supports zero-ETL
-  source_rds_arn                   = module.rds.database_arn
+  source_rds_arn                   = module.rds.cluster_arn              # Use cluster_arn for Aurora
   source_rds_security_group_id     = module.rds.database_security_group_id
 }
 
@@ -94,7 +96,7 @@ module "redshift_serverless" {
 
   # RDS Integration (optional - only for Aurora MySQL/PostgreSQL or RDS MySQL)
   create_rds_integration           = false  # Set to true if your RDS supports zero-ETL
-  source_rds_arn                   = module.stack.database_arn
+  source_rds_arn                   = module.stack.cluster_arn            # Use cluster_arn for Aurora
   source_rds_security_group_id     = module.stack.database_security_group_id
 }
 ```
@@ -165,7 +167,7 @@ connection = PG.connect(ENV["REDSHIFT_CONNECTION_URL"])
   - `subnet_ids`: From `module.vpc.subnet_private_ids`
 
 - **RDS (already in place)**
-  - `source_rds_arn`: From `module.rds.database_arn`
+  - `source_rds_arn`: From `module.rds.cluster_arn`
   - `source_rds_security_group_id`: From `module.rds.database_security_group_id`
 
 - **ECS (already in place)**

--- a/aws/redshift/serverless/README.md
+++ b/aws/redshift/serverless/README.md
@@ -24,8 +24,6 @@ RDS zero-ETL integration is **only supported** for:
 
 ❌ **Not supported**: Regular RDS PostgreSQL instances
 
-Set `create_rds_integration = true` only if your RDS instance supports zero-ETL.
-
 **For Aurora clusters**: Use the **cluster ARN** (from `aws_rds_cluster`), not the instance ARN (from `aws_rds_cluster_instance`). Aurora creates both a cluster and instances, but the zero-ETL integration requires the cluster ARN.
 
 ### Password Requirements
@@ -68,7 +66,6 @@ module "redshift_serverless" {
   ecs_security_group_id = module.ecs.ecs_security_group_id
 
   # RDS Integration (optional - only for Aurora MySQL/PostgreSQL or RDS MySQL)
-  create_rds_integration           = false  # Set to true if your RDS supports zero-ETL
   source_rds_arn                   = module.rds.cluster_arn              # Use cluster_arn for Aurora
   source_rds_security_group_id     = module.rds.database_security_group_id
 }
@@ -95,7 +92,6 @@ module "redshift_serverless" {
   ecs_security_group_id = module.stack.ecs_security_group_id
 
   # RDS Integration (optional - only for Aurora MySQL/PostgreSQL or RDS MySQL)
-  create_rds_integration           = false  # Set to true if your RDS supports zero-ETL
   source_rds_arn                   = module.stack.cluster_arn            # Use cluster_arn for Aurora
   source_rds_security_group_id     = module.stack.database_security_group_id
 }

--- a/aws/redshift/serverless/README.md
+++ b/aws/redshift/serverless/README.md
@@ -201,3 +201,5 @@ connection = PG.connect(ENV["REDSHIFT_CONNECTION_URL"])
 **Human Access**: Developers should connect through a bastion host deployed in ECS using IAM authentication. Access is managed through the separate `iam/iam-policy-for-redshift-serverless` module which uses tag-based access control. Users with matching Project/Environment tags automatically get access to Redshift Serverless resources.
 
 **Tagging**: The Redshift Serverless resources (namespace, workgroup) are automatically tagged with Project and Environment values to enable tag-based access control.
+
+**Note**: If you're using the NAT module and adding a third subnet, ensure you're using a version that includes the fix for dynamic subnet creation. Older versions may fail with "Invalid for_each argument" errors.

--- a/aws/redshift/serverless/README.md
+++ b/aws/redshift/serverless/README.md
@@ -22,7 +22,7 @@ The module will automatically read this password from your existing app secrets 
 
 ```terraform
 module "redshift_serverless" {
-  source = "github.com/dbl-works/terraform//redshift/serverless?ref=v2021.07.01"
+  source = "github.com/dbl-works/terraform//aws/redshift/serverless?ref=v2021.07.01"
 
   region      = "eu-central-1"
   project     = "someproject"

--- a/aws/redshift/serverless/README.md
+++ b/aws/redshift/serverless/README.md
@@ -4,47 +4,82 @@
 
 ## Usage
 
-Pass in VPC, subnet, RDS ARN, and ECS security group/role variables from your existing modules.
-Provision Redshift Serverless, endpoint access, zero-ETL integration, and security/IAM for ECS access.
-
 ```terraform
 module "redshift_serverless" {
-  source                     = "github.com/dbl-works/terraform//redshift/serverless?ref=v2021.07.01"
+  source = "github.com/dbl-works/terraform//redshift/serverless?ref=v2021.07.01"
 
-  region                     = "eu-central-1"
-  vpc_id                     = module.vpc.vpc_id
-  subnet_ids                 = module.vpc.private_subnets
-  project                    = "someproject"
-  environment                = "staging"
+  region      = "eu-central-1"
+  project     = "someproject"
+  environment = "staging"
 
-  source_rds_arn              = module.rds.database_identifier
-  ecs_tasks_security_group_id = module.ecs.tasks_security_group_id
-  ecs_task_role_arn           = module.ecs.task_role_arn
+  # Authentication
+  admin_password = var.redshift_password  # For application access (store in AWS Secrets Manager)
+
+  # VPC Configuration
+  vpc_id     = module.vpc.id
+  subnet_ids = module.vpc.subnet_private_ids
+
+  # RDS Configuration (for zero-ETL)
+  source_rds_arn               = module.rds.database_arn
+  source_rds_security_group_id = module.rds.database_security_group_id
+
+  # ECS Configuration
+  ecs_security_group_id = module.ecs.ecs_security_group_id
 }
+
+# Your application connects using password from Secrets Manager
+# Developers connect via bastion host using IAM authentication
 ```
 
-## Implementation Plan (with Existing ECS, RDS, and VPC)
+In a Ruby app:
+
+```ruby
+connection = PG.connect(
+  host: "module.redshift_serverless.endpoint",
+  port: 5439,
+  dbname: "mydb",
+  user: "admin",
+  password: "var.redshift_password",
+)
+```
+
+### Module Outputs
+
+- `endpoint`: Redshift Serverless endpoint for connections
+- `database_name`: Name of the database
+- `admin_username`: Admin username for password authentication
+- `iam_role_arn_admin`: IAM role ARN for admin access (human users)
+- `iam_role_arn_readonly`: IAM role ARN for readonly access (human users)
+
+## Implementation Plan
+
+### Authentication Strategy
+
+- **Applications (ECS)**: Use password authentication with credentials stored in AWS Secrets Manager
+- **Human Users (Developers)**: Use IAM authentication via bastion host running in ECS
 
 ### Variables to Pass In
 
-- **ECS (already in place)**
-  - `ecs_tasks_security_group_id`: Security group ID for ECS tasks (to allow Redshift access)
-  - (Optional) `ecs_task_role_arn`: IAM role ARN for ECS tasks (for IAM authentication to Redshift)
-
-- **RDS (already in place)**
-  - `source_rds_arn`: ARN of the RDS instance (for zero-ETL integration)
-  - (Optional) `source_rds_security_group_id`: Security group ID for RDS (if needed for networking rules)
+- **Authentication**
+  - `admin_password`: Password for the admin user (applications will use this)
 
 - **VPC (already in place)**
-  - `vpc_id`: VPC ID where all resources are deployed
-  - `subnet_ids`: List of private subnet IDs for Redshift Serverless endpoint access
+  - `vpc_id`: From `module.vpc.id`
+  - `subnet_ids`: From `module.vpc.subnet_private_ids`
+
+- **RDS (already in place)**
+  - `source_rds_arn`: From `module.rds.database_arn`
+  - `source_rds_security_group_id`: From `module.rds.database_security_group_id`
+
+- **ECS (already in place)**
+  - `ecs_security_group_id`: From `module.ecs.ecs_security_group_id`
 
 ---
 
 ### Terraform Resources
 
 - `aws_redshiftserverless_namespace`:
-  Defines the Redshift Serverless logical database environment.
+  Defines the Redshift Serverless logical database environment with admin credentials.
 
 - `aws_redshiftserverless_workgroup`:
   Configures compute resources and networking for Redshift Serverless.
@@ -55,10 +90,19 @@ module "redshift_serverless" {
 - `aws_rds_integration`:
   Sets up the zero-ETL pipeline from RDS to Redshift Serverless.
 
-- `aws_security_group`:
-  Allows ECS tasks to connect to Redshift Serverless (ingress on port 5439).
-  - Reference `ecs_tasks_security_group_id` for ingress rules.
+- `aws_security_group` (for Redshift):
+  Creates a new security group for Redshift with:
+  - Ingress from `ecs_security_group_id` on port 5439 (for both apps and bastion)
+  - Ingress from `source_rds_security_group_id` (for zero-ETL)
 
-- `aws_iam_policy` & `aws_iam_role_policy_attachment`:
-  Grants ECS task role permission to authenticate to Redshift (IAM auth).
-  - Reference `ecs_task_role_arn` if using IAM authentication.
+- `aws_iam_group` and `aws_iam_policy` (for human access):
+  Creates IAM groups and policies for developers to connect via bastion host:
+  - `redshift-serverless-admin`: Full access for admin users
+  - `redshift-serverless-readonly`: Read-only access for developers
+  - Policies grant `redshift-serverless:GetCredentials` for IAM authentication
+
+---
+
+### Note
+
+Applications should retrieve the Redshift password from AWS Secrets Manager at runtime. Human users should connect through a bastion host deployed in ECS using IAM authentication, similar to the RDS access pattern.

--- a/aws/redshift/serverless/README.md
+++ b/aws/redshift/serverless/README.md
@@ -1,0 +1,64 @@
+# Redshift Serverless
+
+[Docs](https://registry.terraform.io/providers/hashicorp/aws/5.99.0/docs/resources/redshiftserverless_workgroup)
+
+## Usage
+
+Pass in VPC, subnet, RDS ARN, and ECS security group/role variables from your existing modules.
+Provision Redshift Serverless, endpoint access, zero-ETL integration, and security/IAM for ECS access.
+
+```terraform
+module "redshift_serverless" {
+  source                     = "github.com/dbl-works/terraform//redshift/serverless?ref=v2021.07.01"
+
+  region                     = "eu-central-1"
+  vpc_id                     = module.vpc.vpc_id
+  subnet_ids                 = module.vpc.private_subnets
+  project                    = "someproject"
+  environment                = "staging"
+
+  source_rds_arn              = module.rds.database_identifier
+  ecs_tasks_security_group_id = module.ecs.tasks_security_group_id
+  ecs_task_role_arn           = module.ecs.task_role_arn
+}
+```
+
+## Implementation Plan (with Existing ECS, RDS, and VPC)
+
+### Variables to Pass In
+
+- **ECS (already in place)**
+  - `ecs_tasks_security_group_id`: Security group ID for ECS tasks (to allow Redshift access)
+  - (Optional) `ecs_task_role_arn`: IAM role ARN for ECS tasks (for IAM authentication to Redshift)
+
+- **RDS (already in place)**
+  - `source_rds_arn`: ARN of the RDS instance (for zero-ETL integration)
+  - (Optional) `source_rds_security_group_id`: Security group ID for RDS (if needed for networking rules)
+
+- **VPC (already in place)**
+  - `vpc_id`: VPC ID where all resources are deployed
+  - `subnet_ids`: List of private subnet IDs for Redshift Serverless endpoint access
+
+---
+
+### Terraform Resources
+
+- `aws_redshiftserverless_namespace`:
+  Defines the Redshift Serverless logical database environment.
+
+- `aws_redshiftserverless_workgroup`:
+  Configures compute resources and networking for Redshift Serverless.
+
+- `aws_redshiftserverless_endpoint_access`:
+  Creates a VPC endpoint for private access to Redshift Serverless.
+
+- `aws_rds_integration`:
+  Sets up the zero-ETL pipeline from RDS to Redshift Serverless.
+
+- `aws_security_group`:
+  Allows ECS tasks to connect to Redshift Serverless (ingress on port 5439).
+  - Reference `ecs_tasks_security_group_id` for ingress rules.
+
+- `aws_iam_policy` & `aws_iam_role_policy_attachment`:
+  Grants ECS task role permission to authenticate to Redshift (IAM auth).
+  - Reference `ecs_task_role_arn` if using IAM authentication.

--- a/aws/redshift/serverless/endpoint-access.tf
+++ b/aws/redshift/serverless/endpoint-access.tf
@@ -1,0 +1,6 @@
+resource "aws_redshiftserverless_endpoint_access" "main" {
+  endpoint_name          = "${local.name}-endpoint"
+  workgroup_name         = aws_redshiftserverless_workgroup.main.workgroup_name
+  subnet_ids             = var.subnet_ids
+  vpc_security_group_ids = [aws_security_group.redshift.id]
+}

--- a/aws/redshift/serverless/main.tf
+++ b/aws/redshift/serverless/main.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/aws/redshift/serverless/main.tf
+++ b/aws/redshift/serverless/main.tf
@@ -1,1 +1,0 @@
-data "aws_caller_identity" "current" {}

--- a/aws/redshift/serverless/namespace.tf
+++ b/aws/redshift/serverless/namespace.tf
@@ -1,7 +1,7 @@
 resource "aws_redshiftserverless_namespace" "main" {
   namespace_name      = "${var.project}-${var.environment}"
   admin_username      = "admin"
-  admin_user_password = var.admin_password
+  admin_user_password = local.infra_credentials.redshift_root_password
   db_name             = replace("${var.project}_${var.environment}", "/[^0-9A-Za-z_]/", "_")
 
   # IAM role for Redshift to access other AWS services (for zero-ETL integration)

--- a/aws/redshift/serverless/namespace.tf
+++ b/aws/redshift/serverless/namespace.tf
@@ -7,6 +7,9 @@ resource "aws_redshiftserverless_namespace" "main" {
   # IAM role for Redshift to access other AWS services (for zero-ETL integration)
   default_iam_role_arn = aws_iam_role.redshift_serverless_default.arn
 
+  # AWS requires the default IAM role to also be included in the iam_roles list
+  iam_roles = [aws_iam_role.redshift_serverless_default.arn]
+
   tags = {
     Name        = "${var.project}-${var.environment}"
     Project     = var.project

--- a/aws/redshift/serverless/namespace.tf
+++ b/aws/redshift/serverless/namespace.tf
@@ -1,0 +1,40 @@
+resource "aws_redshiftserverless_namespace" "main" {
+  namespace_name      = "${var.project}-${var.environment}"
+  admin_username      = "admin"
+  admin_user_password = var.admin_password
+  db_name             = replace("${var.project}_${var.environment}", "/[^0-9A-Za-z_]/", "_")
+
+  # IAM role for Redshift to access other AWS services (for zero-ETL integration)
+  default_iam_role_arn = aws_iam_role.redshift_serverless_default.arn
+
+  tags = {
+    Name        = "${var.project}-${var.environment}"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+# Default IAM role for the Redshift Serverless namespace
+# This role is used by Redshift to access other AWS services like S3, RDS, etc.
+resource "aws_iam_role" "redshift_serverless_default" {
+  name = "${var.project}-${var.environment}-redshift-serverless-default"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "redshift-serverless.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "${var.project}-${var.environment}-redshift-serverless-default"
+    Project     = var.project
+    Environment = var.environment
+  }
+}

--- a/aws/redshift/serverless/outputs.tf
+++ b/aws/redshift/serverless/outputs.tf
@@ -14,9 +14,15 @@ output "admin_username" {
 }
 
 output "connection_url" {
-  description = "Complete PostgreSQL connection URL for Redshift Serverless (copy this to your app secrets as REDSHIFT_CONNECTION_URL)"
+  description = "PostgreSQL-compatible connection URL for Redshift Serverless (for use with pg gem and similar PostgreSQL drivers - copy this to your app secrets as REDSHIFT_CONNECTION_URL)"
   value       = "postgresql://${aws_redshiftserverless_namespace.main.admin_username}:${local.infra_credentials.redshift_root_password}@${aws_redshiftserverless_workgroup.main.endpoint[0].address}:5439/${aws_redshiftserverless_namespace.main.db_name}"
   sensitive   = true
+}
+
+output "jdbc_url" {
+  description = "JDBC URL for Redshift Serverless (for native Redshift drivers)"
+  value       = "jdbc:redshift://${aws_redshiftserverless_workgroup.main.endpoint[0].address}:5439/${aws_redshiftserverless_namespace.main.db_name}"
+  sensitive   = false
 }
 
 output "namespace_arn" {

--- a/aws/redshift/serverless/outputs.tf
+++ b/aws/redshift/serverless/outputs.tf
@@ -1,0 +1,24 @@
+output "endpoint" {
+  description = "Redshift Serverless endpoint for connections"
+  value       = aws_redshiftserverless_workgroup.main.endpoint[0].address
+}
+
+output "database_name" {
+  description = "Name of the database"
+  value       = aws_redshiftserverless_namespace.main.db_name
+}
+
+output "admin_username" {
+  description = "Admin username for password authentication"
+  value       = aws_redshiftserverless_namespace.main.admin_username
+}
+
+output "namespace_arn" {
+  description = "ARN of the Redshift Serverless namespace"
+  value       = aws_redshiftserverless_namespace.main.arn
+}
+
+output "workgroup_arn" {
+  description = "ARN of the Redshift Serverless workgroup"
+  value       = aws_redshiftserverless_workgroup.main.arn
+}

--- a/aws/redshift/serverless/outputs.tf
+++ b/aws/redshift/serverless/outputs.tf
@@ -13,6 +13,12 @@ output "admin_username" {
   value       = aws_redshiftserverless_namespace.main.admin_username
 }
 
+output "connection_url" {
+  description = "Complete PostgreSQL connection URL for Redshift Serverless (copy this to your app secrets as REDSHIFT_CONNECTION_URL)"
+  value       = "postgresql://${aws_redshiftserverless_namespace.main.admin_username}:${local.infra_credentials.redshift_root_password}@${aws_redshiftserverless_workgroup.main.endpoint[0].address}:5439/${aws_redshiftserverless_namespace.main.db_name}"
+  sensitive   = true
+}
+
 output "namespace_arn" {
   description = "ARN of the Redshift Serverless namespace"
   value       = aws_redshiftserverless_namespace.main.arn

--- a/aws/redshift/serverless/rds-integration.tf
+++ b/aws/redshift/serverless/rds-integration.tf
@@ -1,0 +1,11 @@
+resource "aws_rds_integration" "main" {
+  integration_name = "${local.name}-rds-integration"
+  source_arn       = var.source_rds_arn
+  target_arn       = aws_redshiftserverless_namespace.main.arn
+
+  tags = {
+    Name        = "${local.name}-rds-integration"
+    Project     = var.project
+    Environment = var.environment
+  }
+}

--- a/aws/redshift/serverless/security-groups.tf
+++ b/aws/redshift/serverless/security-groups.tf
@@ -38,14 +38,7 @@ resource "aws_security_group_rule" "redshift_from_rds" {
   description              = "Redshift access from RDS for zero-ETL integration"
 }
 
-# Allow all outbound traffic
-# Redshift may need to communicate with AWS services for management and data operations
-resource "aws_security_group_rule" "redshift_egress" {
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = -1
-  security_group_id = aws_security_group.redshift.id
-  cidr_blocks       = ["0.0.0.0/0"]
-  description       = "All outbound traffic"
-}
+# Note: No egress rules defined
+# Redshift Serverless is a fully managed service where AWS handles service-to-service
+# communication through their managed infrastructure. Explicit egress rules are not
+# required for normal operation including zero-ETL integration.

--- a/aws/redshift/serverless/security-groups.tf
+++ b/aws/redshift/serverless/security-groups.tf
@@ -1,7 +1,3 @@
-locals {
-  name = "${var.project}-${var.environment}"
-}
-
 resource "aws_security_group" "redshift" {
   name        = "${local.name}-redshift"
   description = "Security group for Redshift Serverless ${local.name}"

--- a/aws/redshift/serverless/security-groups.tf
+++ b/aws/redshift/serverless/security-groups.tf
@@ -1,0 +1,55 @@
+locals {
+  name = "${var.project}-${var.environment}"
+}
+
+resource "aws_security_group" "redshift" {
+  name        = "${local.name}-redshift"
+  description = "Security group for Redshift Serverless ${local.name}"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name        = "${local.name}-redshift"
+    Project     = var.project
+    Environment = var.environment
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Allow inbound connections from ECS tasks on Redshift port
+# This enables applications running in ECS to connect to Redshift for analytics queries
+resource "aws_security_group_rule" "redshift_from_ecs" {
+  type                     = "ingress"
+  from_port                = 5439
+  to_port                  = 5439
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.redshift.id
+  source_security_group_id = var.ecs_security_group_id
+  description              = "Redshift access from ECS tasks"
+}
+
+# Allow inbound connections from RDS security group for zero-ETL integration
+# This enables the managed zero-ETL service to replicate data from RDS to Redshift
+resource "aws_security_group_rule" "redshift_from_rds" {
+  type                     = "ingress"
+  from_port                = 5439
+  to_port                  = 5439
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.redshift.id
+  source_security_group_id = var.source_rds_security_group_id
+  description              = "Redshift access from RDS for zero-ETL integration"
+}
+
+# Allow all outbound traffic
+# Redshift may need to communicate with AWS services for management and data operations
+resource "aws_security_group_rule" "redshift_egress" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  security_group_id = aws_security_group.redshift.id
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "All outbound traffic"
+}

--- a/aws/redshift/serverless/variables.tf
+++ b/aws/redshift/serverless/variables.tf
@@ -1,14 +1,36 @@
+data "aws_caller_identity" "current" {}
+
 variable "vpc_id" {}
 variable "project" {}
 variable "environment" {}
-variable "subnet_ids" {}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "The subnet IDs to use for the Redshift Serverless workgroup"
+}
 
 variable "region" {
   type    = string
   default = "eu-central-1"
 }
 
+variable "admin_password" {
+  type        = string
+  description = "The password for the admin user"
+  sensitive   = true
+}
+
 variable "source_rds_arn" {
   type        = string
   description = "The identifier of the RDS instance to use as source for the Redshift Serverless workgroup"
+}
+
+variable "source_rds_security_group_id" {
+  type        = string
+  description = "The security group of the RDS instance to use as source for the Redshift Serverless workgroup"
+}
+
+variable "ecs_security_group_id" {
+  type        = string
+  description = "The security group of the ECS cluster to use as source for the Redshift Serverless workgroup"
 }

--- a/aws/redshift/serverless/variables.tf
+++ b/aws/redshift/serverless/variables.tf
@@ -1,0 +1,14 @@
+variable "vpc_id" {}
+variable "project" {}
+variable "environment" {}
+variable "subnet_ids" {}
+
+variable "region" {
+  type    = string
+  default = "eu-central-1"
+}
+
+variable "source_rds_arn" {
+  type        = string
+  description = "The identifier of the RDS instance to use as source for the Redshift Serverless workgroup"
+}

--- a/aws/redshift/serverless/variables.tf
+++ b/aws/redshift/serverless/variables.tf
@@ -1,7 +1,12 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_secretsmanager_secret_version" "app" {
+  secret_id = "${var.project}/infra/${var.environment}"
+}
+
 locals {
-  name = "${var.project}-${var.environment}"
+  name            = "${var.project}-${var.environment}"
+  infra_credentials = jsondecode(data.aws_secretsmanager_secret_version.app.secret_string)
 }
 
 variable "vpc_id" {}
@@ -16,12 +21,6 @@ variable "subnet_ids" {
 variable "region" {
   type    = string
   default = "eu-central-1"
-}
-
-variable "admin_password" {
-  type        = string
-  description = "The password for the admin user"
-  sensitive   = true
 }
 
 variable "source_rds_arn" {

--- a/aws/redshift/serverless/variables.tf
+++ b/aws/redshift/serverless/variables.tf
@@ -1,5 +1,9 @@
 data "aws_caller_identity" "current" {}
 
+locals {
+  name = "${var.project}-${var.environment}"
+}
+
 variable "vpc_id" {}
 variable "project" {}
 variable "environment" {}

--- a/aws/redshift/serverless/variables.tf
+++ b/aws/redshift/serverless/variables.tf
@@ -1,12 +1,12 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_secretsmanager_secret_version" "app" {
+data "aws_secretsmanager_secret_version" "infra" {
   secret_id = "${var.project}/infra/${var.environment}"
 }
 
 locals {
-  name            = "${var.project}-${var.environment}"
-  infra_credentials = jsondecode(data.aws_secretsmanager_secret_version.app.secret_string)
+  name             = "${var.project}-${var.environment}"
+  infra_credentials = jsondecode(data.aws_secretsmanager_secret_version.infra.secret_string)
 }
 
 variable "vpc_id" {}

--- a/aws/redshift/serverless/workgroup.tf
+++ b/aws/redshift/serverless/workgroup.tf
@@ -1,0 +1,44 @@
+resource "aws_redshiftserverless_workgroup" "main" {
+  namespace_name = aws_redshiftserverless_namespace.main.namespace_name
+  workgroup_name = "${var.project}-${var.environment}"
+
+  # Compute capacity (RPUs - Redshift Processing Units)
+  base_capacity = 32  # Start with minimum capacity, can be adjusted
+
+  # Database configuration parameters
+  # Enable automatic materialized views - Redshift automatically creates and maintains
+  # materialized views to speed up frequently used queries without manual intervention
+  config_parameter {
+    parameter_key   = "auto_mv"
+    parameter_value = "true"
+  }
+
+  # Set date format to ISO standard (YYYY-MM-DD) with Month-Day-Year input preference
+  # This ensures consistent date formatting across applications and makes dates human-readable
+  config_parameter {
+    parameter_key   = "datestyle"
+    parameter_value = "ISO, MDY"
+  }
+
+  # Define schema search path - when queries don't specify a schema, Redshift will search:
+  # 1. User's personal schema (if it exists)
+  # 2. The public schema (default for most tables)
+  # This follows PostgreSQL conventions and ensures queries work as expected
+  config_parameter {
+    parameter_key   = "search_path"
+    parameter_value = "$user, public"
+  }
+
+  # Security and networking
+  subnet_ids         = var.subnet_ids
+  security_group_ids = [aws_security_group.redshift.id]
+
+  # Enable public accessibility only if needed (usually false for security)
+  publicly_accessible = false
+
+  tags = {
+    Name        = "${var.project}-${var.environment}"
+    Project     = var.project
+    Environment = var.environment
+  }
+}

--- a/aws/stack/app/aurora.tf
+++ b/aws/stack/app/aurora.tf
@@ -28,6 +28,8 @@ module "aurora" {
   kms_key_arn = module.aurora-kms-key[0].arn
   password    = local.credentials.db_root_password
 
+  engine_version = var.aurora_engine_version
+
   allow_from_cidr_blocks = var.aurora_allow_from_cidr_blocks
   allow_from_security_groups = [
     module.ecs.ecs_security_group_id

--- a/aws/stack/app/aurora.tf
+++ b/aws/stack/app/aurora.tf
@@ -28,7 +28,7 @@ module "aurora" {
   kms_key_arn = module.aurora-kms-key[0].arn
   password    = local.credentials.db_root_password
 
-  allow_from_cidr_blocks = module.ecs.ecs_security_group_cidr_blocks
+  allow_from_cidr_blocks = var.aurora_allow_from_cidr_blocks
   allow_from_security_groups = [
     module.ecs.ecs_security_group_id
   ]

--- a/aws/stack/app/aurora.tf
+++ b/aws/stack/app/aurora.tf
@@ -1,0 +1,39 @@
+module "aurora-kms-key" {
+  source = "../../kms-key"
+  count  = var.skip_aurora ? 0 : 1
+
+  # Required
+  environment = var.environment
+  project     = var.project
+  alias       = "aurora"
+  description = "KMS key for ${var.project}-${var.environment} RDS Aurora."
+
+  # Optional
+  deletion_window_in_days = var.kms_deletion_window_in_days
+  multi_region            = var.rds_multi_region_kms_key
+}
+
+module "aurora" {
+  source = "../../aurora"
+  count  = var.skip_aurora ? 0 : 1
+
+  depends_on = [
+    module.ecs
+  ]
+
+  project     = var.project
+  environment = var.environment
+  vpc_id      = module.vpc.id
+  subnet_ids  = module.vpc.subnet_private_ids
+  kms_key_arn = module.aurora-kms-key[0].arn
+  password    = local.credentials.db_root_password
+
+  allow_from_cidr_blocks = module.ecs.ecs_security_group_cidr_blocks
+  allow_from_security_groups = [
+    module.ecs.ecs_security_group_id
+  ]
+
+  # optional
+  instance_count = var.aurora_instance_count
+  instance_class = var.aurora_instance_class
+}

--- a/aws/stack/app/outputs.tf
+++ b/aws/stack/app/outputs.tf
@@ -23,6 +23,10 @@ output "ecs_security_group_id" {
   value = module.ecs.ecs_security_group_id
 }
 
+output "rds_security_group_id" {
+  value = var.skip_rds ? "" : module.rds[0].database_security_group_id
+}
+
 output "subnet_public_ids" {
   value = module.vpc.subnet_public_ids
 }

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -255,9 +255,27 @@ variable "elasticache_automatic_failover_enabled" {
   type    = bool
   default = true
 }
-# =============== Elasticache ================ #
+# =============== Elasticache - END ================ #
 
-# =============== RDS ================ #
+# =============== AURORA - START ================ #
+variable "skip_aurora" {
+  type    = bool
+  default = true
+}
+
+variable "aurora_instance_count" {
+  type    = number
+  default = 1
+}
+
+variable "aurora_instance_class" {
+  default     = "db.t4g.medium"
+  type        = string
+  description = "Instance class for Aurora cluster instances"
+}
+# =============== AURORA - END ================ #
+
+# =============== RDS - START ================ #
 variable "skip_rds" {
   type    = bool
   default = false

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -274,21 +274,18 @@ variable "aurora_instance_count" {
 }
 
 variable "aurora_instance_class" {
-  default     = "db.serverless"
-  type        = string
-  description = "Instance class for Aurora cluster instances"
+  default = "db.serverless"
+  type    = string
 }
 
 variable "aurora_max_capacity" {
-  type        = number
-  default     = 2.0
-  description = "Maximum capacity for serverless instances (e.g., 1.0, 1.5, 2.0, 2.5, etc.). Only used if instance_class is 'db.serverless'."
+  type    = number
+  default = 2.0
 }
 
 variable "aurora_seconds_until_auto_pause" {
-  type        = number
-  default     = 300
-  description = "Time in seconds until serverless instances automatically pause (from 5 minutes to 24 hours). Only used if instance_class is 'db.serverless'."
+  type    = number
+  default = 300
 }
 # =============== AURORA - END ================ #
 

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -274,7 +274,7 @@ variable "aurora_instance_count" {
 }
 
 variable "aurora_instance_class" {
-  default     = "db.t4g.medium"
+  default     = "db.serverless"
   type        = string
   description = "Instance class for Aurora cluster instances"
 }

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -287,6 +287,11 @@ variable "aurora_seconds_until_auto_pause" {
   type    = number
   default = 300
 }
+
+variable "aurora_engine_version" {
+  type    = string
+  default = "17.4"
+}
 # =============== AURORA - END ================ #
 
 # =============== RDS - START ================ #

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -263,6 +263,11 @@ variable "skip_aurora" {
   default = true
 }
 
+variable "aurora_allow_from_cidr_blocks" {
+  type    = list(string)
+  default = []
+}
+
 variable "aurora_instance_count" {
   type    = number
   default = 1
@@ -272,6 +277,18 @@ variable "aurora_instance_class" {
   default     = "db.t4g.medium"
   type        = string
   description = "Instance class for Aurora cluster instances"
+}
+
+variable "aurora_max_capacity" {
+  type        = number
+  default     = 2.0
+  description = "Maximum capacity for serverless instances (e.g., 1.0, 1.5, 2.0, 2.5, etc.). Only used if instance_class is 'db.serverless'."
+}
+
+variable "aurora_seconds_until_auto_pause" {
+  type        = number
+  default     = 300
+  description = "Time in seconds until serverless instances automatically pause (from 5 minutes to 24 hours). Only used if instance_class is 'db.serverless'."
 }
 # =============== AURORA - END ================ #
 


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

Spin up Redshift Serverless, connects to RDS as source, grants access to ECS so tasks running in ECS can run analytical queries against Redshift instead of RDS.

#### Motivation

<!-- Why are you making this change? -->
