### PR TITLE
Fix cluster mode elasticache ignore values

### DIFF
--- a/aws/elasticache/README.md
+++ b/aws/elasticache/README.md
@@ -43,6 +43,13 @@ module "elasticache" {
   # Compulsory for Cluster Mode
   shard_count = 2
   replicas_per_node_group = 1 # if set to 0, must disable multi-AZ
+
+  # Ignore engine version changes since AWS will auto-update minor version changes
+  lifecycle {
+    ignore_changes = [
+      engine_version,
+    ]
+  }
 }
 ```
 
@@ -62,7 +69,10 @@ Sidekiq does not work with cluster mode. The recommended setup is to have:
 * ca-central-1
 * sa-east-1
 
-As of July 2022. Also, you **must** use Reds `6.2` or later.
+As of July 2025. Also, you **must** use following versions of elasticache:
+
+- Redis `7.1` or later
+- Valkey `8.0` or later
 
 ## Outputs
 

--- a/aws/elasticache/README.md
+++ b/aws/elasticache/README.md
@@ -77,6 +77,8 @@ As of July 2025. Also, you **must** use following versions of elasticache:
 
 ## Migration from Redis 6.2.6
 
+> 💡 We highly recommned migrating to a desired  engine and version right away to save time.
+
 If you're trying to migrate from <7 Redis version to any new version, you'll likely get an error like this:
 
 ```
@@ -89,6 +91,8 @@ In order to successfully migrate you'll have to explicitly set this param to `nu
 # this will ensure that you'll update engine version successfully
 transit_encryption_mode = null
 ```
+
+Once migrated you can enable `transit_encryption_mode` without replacing resource
 
 ## Outputs
 

--- a/aws/elasticache/README.md
+++ b/aws/elasticache/README.md
@@ -74,6 +74,22 @@ As of July 2025. Also, you **must** use following versions of elasticache:
 - Redis `7.1` or later
 - Valkey `8.0` or later
 
+
+## Migration from Redis 6.2.6
+
+If you're trying to migrate from <7 Redis version to any new version, you'll likely get an error like this:
+
+```
+Transit encryption mode is not supported for engine version 6.2.6. Please use engine version 7.0.5 or higher.
+```
+
+In order to successfully migrate you'll have to explicitly set this param to `null`:
+
+```
+# this will ensure that you'll update engine version successfully
+transit_encryption_mode = null
+```
+
 ## Outputs
 
 * `endpoint`

--- a/aws/elasticache/elasticache.tf
+++ b/aws/elasticache/elasticache.tf
@@ -75,13 +75,6 @@ resource "aws_elasticache_replication_group" "cluster_mode" {
     Project     = var.project
     Environment = var.environment
   }
-
-  # Ignore engine version changes since AWS will auto-update minor version changes
-  lifecycle {
-    ignore_changes = [
-      engine_version,
-    ]
-  }
 }
 
 locals {

--- a/aws/stack/app/elasticache.tf
+++ b/aws/stack/app/elasticache.tf
@@ -14,6 +14,7 @@ module "elasticache" {
   ])))
 
   # optional
+  engine                     = var.elasticache_engine
   name                       = var.elasticache_name
   major_version              = var.elasticache_major_version
   node_type                  = var.elasticache_node_type

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -185,6 +185,15 @@ variable "elasticache_node_type" {
   default = "cache.t3.micro"
 }
 
+variable "elasticache_engine" {
+  type    = string
+  default = "redis"
+  validation {
+    condition     = contains(["redis", "valkey"], var.elasticache_engine)
+    error_message = "elasticache engine must be either 'redis' or 'valkey'"
+  }
+}
+
 variable "elasticache_major_version" {
   type    = number
   default = 7

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -194,12 +194,15 @@ variable "elasticache_engine" {
   }
 }
 
+locals {
+  major_version_bounds = var.elasticache_engine == "valkey" ? [7, 8] : [6, 7]
+}
 variable "elasticache_major_version" {
   type    = number
   default = 7
   validation {
-    condition     = var.elasticache_major_version >= 6 && var.elasticache_major_version <= 7
-    error_message = "elasticache major_version must be 6 or 7"
+    condition     = var.major_version >= local.major_version_bounds[0] && var.major_version <= local.major_version_bounds[1]
+    error_message = "major_version must be ${local.major_version_bounds[0]} or ${local.major_version_bounds[1]}"
   }
 }
 

--- a/aws/stack/app/variables.tf
+++ b/aws/stack/app/variables.tf
@@ -201,8 +201,8 @@ variable "elasticache_major_version" {
   type    = number
   default = 7
   validation {
-    condition     = var.major_version >= local.major_version_bounds[0] && var.major_version <= local.major_version_bounds[1]
-    error_message = "major_version must be ${local.major_version_bounds[0]} or ${local.major_version_bounds[1]}"
+    condition     = var.elasticache_major_version >= local.major_version_bounds[0] && var.elasticache_major_version <= local.major_version_bounds[1]
+    error_message = "elasticache_major_version must be ${local.major_version_bounds[0]} or ${local.major_version_bounds[1]}"
   }
 }
 


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

Turns out in my last PR #377 I forgot to remove `ignore_values` lifecycle for `cluster_mode` block 🙈. This PR fixes it.

Bonus: I noticed we have outdated docs so did a tiny brush up there as well to be up to date.

#### Motivation

<!-- Why are you making this change? -->

#### Testing

I've migrated our clustered redis to valkey on production, the migration went successful 👍🏼 