### PR TITLE
Fix aurora cluster instance resource

### DIFF
--- a/aws/aurora/main.tf
+++ b/aws/aurora/main.tf
@@ -69,7 +69,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   count = var.instance_count
 
   identifier              = "${var.project}-${var.environment}-node-${count.index}"
-  cluster_identifier      = aws_rds_cluster.main.id
+  cluster_identifier      = aws_rds_cluster.main.cluster_identifier
   instance_class          = var.instance_class
   engine                  = aws_rds_cluster.main.engine
   engine_version          = aws_rds_cluster.main.engine_version


### PR DESCRIPTION
#### Summary

When applying changes from terraform using `id` results in it returning ARN which then is throwing an error during apply:

```
operation error RDS: ModifyDBCluster, https response error StatusCode: 400, RequestID: f22e96cd-b89d-4d1d-9a36-c72a90c02ed7, api error InvalidParameterValue: Invalid database cluster identifier:  arn:aws:rds:eu-central-1:0000000000:cluster:some-cluster-identifier
```

#### Motivation

Fix apply action from terraform
