### PR TITLE
feat: AWS GuardDuty Malware Protection for S3

### DIFF
--- a/aws/architecture.md
+++ b/aws/architecture.md
@@ -273,7 +273,7 @@ flowchart TD
     S3[S3 Bucket <br/> Public/Private Storage]:::aws
     
     GD[GuardDuty Malware <br/> Protection Plan]:::security
-    EventBus[EventBridge <br/> Default Bus]:::aws
+    EventBus[EventBridge Default Bus <br/> exists automatically]:::aws
     
     TBAC{S3 Bucket Policy <br/> TBAC Evaluation}
     CleanFile[Clean File <br/> Tag: NO_THREATS_FOUND]:::clean

--- a/aws/architecture.md
+++ b/aws/architecture.md
@@ -255,3 +255,40 @@ graph TD
     RDS -. "Replication/ETL" .-> Redshift
     Aurora -. "Replication/ETL" .-> Redshift
 ```
+
+## Cloud Storage Security (S3 Malware Scanning)
+
+To protect downstream users and internal systems from malicious files uploaded to our buckets, we employ **AWS GuardDuty Malware Protection for S3**. This operates natively at the bucket level without requiring the broader GuardDuty account service.
+
+When a file is uploaded, GuardDuty automatically reads and scans the object, then applies a Tag-Based Access Control (TBAC) tag (`GuardDutyMalwareScanStatus`) to the object. A strict bucket policy actively denies read access (like `s3:GetObject`) if the file is tagged as infected or hasn't successfully passed a scan yet.
+
+```mermaid
+flowchart TD
+    classDef aws fill:#FF9900,stroke:#232F3E,stroke-width:2px,color:#232F3E;
+    classDef external fill:#f6f6f6,stroke:#333,stroke-width:2px;
+    classDef security fill:#DD344C,stroke:#232F3E,stroke-width:2px,color:#fff;
+    classDef clean fill:#228B22,stroke:#006400,stroke-width:2px,color:#fff;
+
+    User((User / Application)):::external
+    S3[S3 Bucket <br/> Public/Private Storage]:::aws
+    
+    GD[GuardDuty Malware <br/> Protection Plan]:::security
+    EventBus[EventBridge <br/> Default Bus]:::aws
+    
+    TBAC{S3 Bucket Policy <br/> TBAC Evaluation}
+    CleanFile[Clean File <br/> Tag: NO_THREATS_FOUND]:::clean
+    InfectedFile[Infected File <br/> Tag: THREATS_FOUND]:::security
+    
+    User -- "Uploads File" --> S3
+    S3 -. "Triggers Scan" .-> GD
+    
+    GD -- "Publishes Scan Metric" --> EventBus
+    GD -- "Applies Tag Result" --> S3
+    
+    S3 --> CleanFile
+    S3 --> InfectedFile
+    
+    User -- "Requests Download" --> TBAC
+    TBAC -- "Allows `s3:GetObject`" --> CleanFile
+    TBAC -- "Denies `s3:GetObject`" --> InfectedFile
+```

--- a/aws/redshift/serverless/variables.tf
+++ b/aws/redshift/serverless/variables.tf
@@ -5,7 +5,7 @@ data "aws_secretsmanager_secret_version" "infra" {
 }
 
 locals {
-  name             = "${var.project}-${var.environment}"
+  name              = "${var.project}-${var.environment}"
   infra_credentials = jsondecode(data.aws_secretsmanager_secret_version.infra.secret_string)
 }
 

--- a/aws/redshift/serverless/workgroup.tf
+++ b/aws/redshift/serverless/workgroup.tf
@@ -3,7 +3,7 @@ resource "aws_redshiftserverless_workgroup" "main" {
   workgroup_name = "${var.project}-${var.environment}"
 
   # Compute capacity (RPUs - Redshift Processing Units)
-  base_capacity = 32  # Start with minimum capacity, can be adjusted
+  base_capacity = 32 # Start with minimum capacity, can be adjusted
 
   # Database configuration parameters
   # Enable automatic materialized views - Redshift automatically creates and maintains

--- a/aws/s3-private/README.md
+++ b/aws/s3-private/README.md
@@ -35,6 +35,10 @@ module "s3-storage" {
       kms_arn = "arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
     }
    ]
+  file_malwarescanning = {
+    enabled                           = true
+    allow_downloading_unscanned_files = true
+  }
 }
 ```
 

--- a/aws/s3-private/README.md
+++ b/aws/s3-private/README.md
@@ -37,7 +37,7 @@ module "s3-storage" {
    ]
   file_malwarescanning = {
     enabled                           = true
-    allow_downloading_unscanned_files = true
+    allow_downloading_unscanned_files = false
   }
 }
 ```

--- a/aws/s3-private/s3.tf
+++ b/aws/s3-private/s3.tf
@@ -10,6 +10,7 @@ module "s3" {
   multi_region_kms_key        = var.multi_region_kms_key
   enable_encryption           = var.sse_algorithm == "aws:kms"
   writers                     = var.writers
+  file_malwarescanning        = var.file_malwarescanning
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "main-bucket-lifecycle-rule" {

--- a/aws/s3-private/variables.tf
+++ b/aws/s3-private/variables.tf
@@ -109,7 +109,7 @@ variable "file_malwarescanning" {
     allow_downloading_unscanned_files = bool
   })
   default = {
-    enabled                           = false
-    allow_downloading_unscanned_files = true
+    enabled                           = true
+    allow_downloading_unscanned_files = false
   }
 }

--- a/aws/s3-private/variables.tf
+++ b/aws/s3-private/variables.tf
@@ -101,3 +101,15 @@ variable "writers" {
   }))
   default = []
 }
+
+variable "file_malwarescanning" {
+  description = "Configuration for AWS GuardDuty Malware Protection for S3."
+  type = object({
+    enabled                           = bool
+    allow_downloading_unscanned_files = bool
+  })
+  default = {
+    enabled                           = false
+    allow_downloading_unscanned_files = true
+  }
+}

--- a/aws/s3-public/README.md
+++ b/aws/s3-public/README.md
@@ -21,6 +21,10 @@ module "s3-frontend" {
   versioning                      = false
   primary_storage_class_retention = 0
   s3_replicas                     = []
+  file_malwarescanning = {
+    enabled                           = true
+    allow_downloading_unscanned_files = true
+  }
 }
 ```
 

--- a/aws/s3-public/README.md
+++ b/aws/s3-public/README.md
@@ -23,7 +23,7 @@ module "s3-frontend" {
   s3_replicas                     = []
   file_malwarescanning = {
     enabled                           = true
-    allow_downloading_unscanned_files = true
+    allow_downloading_unscanned_files = false
   }
 }
 ```

--- a/aws/s3-public/s3.tf
+++ b/aws/s3-public/s3.tf
@@ -1,11 +1,12 @@
 module "s3" {
   source = "../s3"
 
-  environment       = var.environment
-  project           = var.project
-  bucket_name       = var.bucket_name
-  versioning        = var.versioning
-  enable_encryption = false
+  environment          = var.environment
+  project              = var.project
+  bucket_name          = var.bucket_name
+  versioning           = var.versioning
+  enable_encryption    = false
+  file_malwarescanning = var.file_malwarescanning
 }
 
 resource "aws_s3_bucket_acl" "main-bucket-data-acl" {

--- a/aws/s3-public/variables.tf
+++ b/aws/s3-public/variables.tf
@@ -33,7 +33,7 @@ variable "file_malwarescanning" {
     allow_downloading_unscanned_files = bool
   })
   default = {
-    enabled                           = false
-    allow_downloading_unscanned_files = true
+    enabled                           = true
+    allow_downloading_unscanned_files = false
   }
 }

--- a/aws/s3-public/variables.tf
+++ b/aws/s3-public/variables.tf
@@ -25,3 +25,15 @@ variable "s3_replicas" {
     bucket_arn = string,
   }))
 }
+
+variable "file_malwarescanning" {
+  description = "Configuration for AWS GuardDuty Malware Protection for S3."
+  type = object({
+    enabled                           = bool
+    allow_downloading_unscanned_files = bool
+  })
+  default = {
+    enabled                           = false
+    allow_downloading_unscanned_files = true
+  }
+}

--- a/aws/s3-shared/README.md
+++ b/aws/s3-shared/README.md
@@ -14,6 +14,10 @@ module "s3-shared-client_A" {
   project            = "someproject"
   guest_account_name = "client_A"
   region_name        = "eu-central-1"
+  file_malwarescanning = {
+    enabled                           = true
+    allow_downloading_unscanned_files = true
+  }
 }
 ```
 

--- a/aws/s3-shared/README.md
+++ b/aws/s3-shared/README.md
@@ -16,7 +16,7 @@ module "s3-shared-client_A" {
   region_name        = "eu-central-1"
   file_malwarescanning = {
     enabled                           = true
-    allow_downloading_unscanned_files = true
+    allow_downloading_unscanned_files = false
   }
 }
 ```

--- a/aws/s3-shared/main.tf
+++ b/aws/s3-shared/main.tf
@@ -8,6 +8,7 @@ module "s3" {
   versioning           = true
   multi_region_kms_key = false
   enable_encryption    = false
+  file_malwarescanning = var.file_malwarescanning
 }
 
 

--- a/aws/s3-shared/variables.tf
+++ b/aws/s3-shared/variables.tf
@@ -30,7 +30,7 @@ variable "file_malwarescanning" {
     allow_downloading_unscanned_files = bool
   })
   default = {
-    enabled                           = false
-    allow_downloading_unscanned_files = true
+    enabled                           = true
+    allow_downloading_unscanned_files = false
   }
 }

--- a/aws/s3-shared/variables.tf
+++ b/aws/s3-shared/variables.tf
@@ -22,3 +22,15 @@ variable "region_name" {
 locals {
   bucket_name = "${var.project}-${var.environment}-${var.region_name}-shared-${var.guest_account_name}"
 }
+
+variable "file_malwarescanning" {
+  description = "Configuration for AWS GuardDuty Malware Protection for S3."
+  type = object({
+    enabled                           = bool
+    allow_downloading_unscanned_files = bool
+  })
+  default = {
+    enabled                           = false
+    allow_downloading_unscanned_files = true
+  }
+}

--- a/aws/s3/README.md
+++ b/aws/s3/README.md
@@ -19,3 +19,55 @@ module "s3" {
   multi_region_kms_key        = false  # If true, the KMS key can be used in other regions
 }
 ```
+
+## Malware Scanning
+
+This module supports automatic malware scanning of uploaded objects using [AWS GuardDuty Malware Protection for S3](https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection-s3.html). This feature works independently — it does **not** require enabling the full GuardDuty service.
+
+When enabled, every newly uploaded object is automatically scanned and tagged with a `GuardDutyMalwareScanStatus` tag (`NO_THREATS_FOUND`, `THREATS_FOUND`, `UNSUPPORTED`, etc.).
+
+### Configuration
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `file_malwarescanning_enabled` | `bool` | `false` | Enable GuardDuty Malware Protection for S3 on this bucket. |
+| `allow_downloading_unscanned_files` | `bool` | `true` | If `true`, only blocks downloads of files tagged as `THREATS_FOUND`. If `false`, blocks any file not explicitly tagged as `NO_THREATS_FOUND`. |
+
+```terraform
+module "s3" {
+  source = "../s3"
+
+  environment = "staging"
+  project     = "someproject"
+  bucket_name = "someproject-staging-uploads"
+
+  file_malwarescanning_enabled      = true
+  allow_downloading_unscanned_files = true  # Set to false after backfilling scans
+}
+```
+
+### Enabling on an Existing Bucket
+
+When enabling malware scanning on a bucket that already contains files, follow these steps:
+
+1. **Deploy with scanning enabled** and `allow_downloading_unscanned_files = true` (the default). This ensures new uploads are scanned while existing files remain downloadable.
+
+2. **Backfill scans for historical files** using the provided utility script:
+   ```sh
+   export AWS_PROFILE=your-profile
+
+   # Scan the entire bucket (skips already-tagged objects, safe to stop and re-run)
+   ./script/backfill_s3_malware_scan.sh <bucket-name>
+
+   # Scan a specific prefix
+   ./script/backfill_s3_malware_scan.sh <bucket-name> --prefix uploads/ --region eu-central-1
+   ```
+
+3. **Once all objects are tagged**, change `allow_downloading_unscanned_files = false` and apply. Only confirmed clean files will be downloadable from this point on.
+
+### Pricing
+
+GuardDuty Malware Protection for S3 costs approximately **~$0.10 per GiB scanned**.
+
+- [GuardDuty Malware Protection for S3 — Pricing](https://docs.aws.amazon.com/guardduty/latest/ug/pricing-malware-protection-for-s3-guardduty.html)
+- [Amazon GuardDuty Malware Protection for S3 — Price Reduction Announcement](https://aws.amazon.com/about-aws/whats-new/2025/02/amazon-guardduty-malware-protection-s3-price-reduction/)

--- a/aws/s3/README.md
+++ b/aws/s3/README.md
@@ -30,8 +30,8 @@ When enabled, every newly uploaded object is automatically scanned and tagged wi
 
 | Variable | Type | Default | Description |
 |---|---|---|---|
-| `file_malwarescanning.enabled` | `bool` | `false` | Enable GuardDuty Malware Protection for S3 on this bucket. |
-| `file_malwarescanning.allow_downloading_unscanned_files` | `bool` | `true` | If `true`, only blocks downloads of files tagged as `THREATS_FOUND`. If `false`, blocks any file not explicitly tagged as `NO_THREATS_FOUND`. |
+| `file_malwarescanning.enabled` | `bool` | `true` | Enable GuardDuty Malware Protection for S3 on this bucket. |
+| `file_malwarescanning.allow_downloading_unscanned_files` | `bool` | `false` | If `true`, only blocks downloads of files tagged as `THREATS_FOUND`. If `false` (default for security), blocks any file not explicitly tagged as `NO_THREATS_FOUND`. |
 
 ```terraform
 module "s3" {
@@ -41,9 +41,10 @@ module "s3" {
   project     = "someproject"
   bucket_name = "someproject-staging-uploads"
 
+  # Override defaults if you are migrating an existing bucket
   file_malwarescanning = {
     enabled                           = true
-    allow_downloading_unscanned_files = true  # Set to false after backfilling scans
+    allow_downloading_unscanned_files = true  # Switch back to false (default) after backfilling scans
   }
 }
 ```
@@ -52,7 +53,7 @@ module "s3" {
 
 When enabling malware scanning on a bucket that already contains files, follow these steps:
 
-1. **Deploy with scanning enabled** and `allow_downloading_unscanned_files = true` (the default). This ensures new uploads are scanned while existing files remain downloadable.
+1. **Deploy with scanning enabled** and explicitly set `allow_downloading_unscanned_files = true` (overriding the default `false`). This ensures new uploads are scanned while existing files remain downloadable.
 
 2. **Backfill scans for historical files** using the provided utility script:
    ```sh
@@ -65,7 +66,7 @@ When enabling malware scanning on a bucket that already contains files, follow t
    ./script/backfill_s3_malware_scan.sh <bucket-name> --prefix uploads/ --region eu-central-1
    ```
 
-3. **Once all objects are tagged**, change `allow_downloading_unscanned_files = false` and apply. Only confirmed clean files will be downloadable from this point on.
+3. **Once all objects are tagged**, you can safely remove the `allow_downloading_unscanned_files` override from your Terraform code, allowing it to fall back to the secure `false` default. Only confirmed clean files will be downloadable from this point on.
 
 ### Pricing
 

--- a/aws/s3/README.md
+++ b/aws/s3/README.md
@@ -53,16 +53,32 @@ module "s3" {
 
 When enabling malware scanning on a bucket that already contains files, follow these steps:
 
-1. **Deploy with scanning enabled** and explicitly set `allow_downloading_unscanned_files = true` (overriding the default `false`). This ensures new uploads are scanned while existing files remain downloadable.
+1. **Deploy with scanning enabled** and explicitly set `allow_downloading_unscanned_files = true` (overriding the default `false`). This ensures new uploads are scanned while existing files remain downloadable:
+   ```hcl
+   file_malwarescanning = {
+     enabled                           = true
+     allow_downloading_unscanned_files = true  # required during backfill
+   }
+   ```
+   Then run `terraform apply`.
 
-2. **Backfill scans for historical files** using the provided script. This creates an S3 Batch Operations job that runs entirely server-side in AWS — you can close your terminal after launching:
+2. **Backfill scans for historical files** using the provided script. The script performs an in-place copy of each object, which triggers GuardDuty to scan it via EventBridge. The job runs entirely server-side in AWS — you can close your terminal after launching:
    ```sh
    export AWS_PROFILE=your-profile
-   ./script/backfill_s3_malware_scan.sh <bucket-name> --region eu-central-1
+   ./script/backfill_s3_malware_scan.sh --bucket <bucket-name> --region eu-central-1
    ```
    Monitor progress in the AWS Console → S3 → Batch Operations.
 
-3. **Once all objects are tagged**, remove the `allow_downloading_unscanned_files` override from your Terraform code, allowing it to fall back to the secure `false` default. Only confirmed clean files will be downloadable from this point on.
+   > **Note:** The script will abort if it detects the strict bucket policy is active. You _must_ complete step 1 first.
+
+3. **Once all objects are tagged**, remove the `allow_downloading_unscanned_files` override from your Terraform code, allowing it to fall back to the secure `false` default:
+   ```hcl
+   file_malwarescanning = {
+     enabled = true
+     # allow_downloading_unscanned_files defaults to false
+   }
+   ```
+   Run `terraform apply` again. Only confirmed clean files will be downloadable from this point on.
 
 ### Pricing
 

--- a/aws/s3/README.md
+++ b/aws/s3/README.md
@@ -55,18 +55,14 @@ When enabling malware scanning on a bucket that already contains files, follow t
 
 1. **Deploy with scanning enabled** and explicitly set `allow_downloading_unscanned_files = true` (overriding the default `false`). This ensures new uploads are scanned while existing files remain downloadable.
 
-2. **Backfill scans for historical files** using the provided utility script:
+2. **Backfill scans for historical files** using the provided script. This creates an S3 Batch Operations job that runs entirely server-side in AWS — you can close your terminal after launching:
    ```sh
    export AWS_PROFILE=your-profile
-
-   # Scan the entire bucket (skips already-tagged objects, safe to stop and re-run)
-   ./script/backfill_s3_malware_scan.sh <bucket-name>
-
-   # Scan a specific prefix
-   ./script/backfill_s3_malware_scan.sh <bucket-name> --prefix uploads/ --region eu-central-1
+   ./script/backfill_s3_malware_scan.sh <bucket-name> --region eu-central-1
    ```
+   Monitor progress in the AWS Console → S3 → Batch Operations.
 
-3. **Once all objects are tagged**, you can safely remove the `allow_downloading_unscanned_files` override from your Terraform code, allowing it to fall back to the secure `false` default. Only confirmed clean files will be downloadable from this point on.
+3. **Once all objects are tagged**, remove the `allow_downloading_unscanned_files` override from your Terraform code, allowing it to fall back to the secure `false` default. Only confirmed clean files will be downloadable from this point on.
 
 ### Pricing
 

--- a/aws/s3/README.md
+++ b/aws/s3/README.md
@@ -30,8 +30,8 @@ When enabled, every newly uploaded object is automatically scanned and tagged wi
 
 | Variable | Type | Default | Description |
 |---|---|---|---|
-| `file_malwarescanning_enabled` | `bool` | `false` | Enable GuardDuty Malware Protection for S3 on this bucket. |
-| `allow_downloading_unscanned_files` | `bool` | `true` | If `true`, only blocks downloads of files tagged as `THREATS_FOUND`. If `false`, blocks any file not explicitly tagged as `NO_THREATS_FOUND`. |
+| `file_malwarescanning.enabled` | `bool` | `false` | Enable GuardDuty Malware Protection for S3 on this bucket. |
+| `file_malwarescanning.allow_downloading_unscanned_files` | `bool` | `true` | If `true`, only blocks downloads of files tagged as `THREATS_FOUND`. If `false`, blocks any file not explicitly tagged as `NO_THREATS_FOUND`. |
 
 ```terraform
 module "s3" {
@@ -41,8 +41,10 @@ module "s3" {
   project     = "someproject"
   bucket_name = "someproject-staging-uploads"
 
-  file_malwarescanning_enabled      = true
-  allow_downloading_unscanned_files = true  # Set to false after backfilling scans
+  file_malwarescanning = {
+    enabled                           = true
+    allow_downloading_unscanned_files = true  # Set to false after backfilling scans
+  }
 }
 ```
 

--- a/aws/s3/main.tf
+++ b/aws/s3/main.tf
@@ -160,7 +160,10 @@ data "aws_iam_policy_document" "bucket_policy" {
       condition {
         test     = "StringNotLike"
         variable = "aws:PrincipalArn"
-        values   = [aws_iam_role.guardduty_malware_protection[0].arn]
+        values = [
+          aws_iam_role.guardduty_malware_protection[0].arn,
+          "arn:aws:iam::*:role/gd-backfill-lambda-*"
+        ]
       }
     }
   }

--- a/aws/s3/main.tf
+++ b/aws/s3/main.tf
@@ -160,11 +160,7 @@ data "aws_iam_policy_document" "bucket_policy" {
       condition {
         test     = "StringNotLike"
         variable = "aws:PrincipalArn"
-        values = [
-          aws_iam_role.guardduty_malware_protection[0].arn,
-          "arn:aws:iam::*:role/gd-backfill-lambda-*",
-          "arn:aws:sts::*:assumed-role/gd-backfill-lambda-*/*"
-        ]
+        values   = [aws_iam_role.guardduty_malware_protection[0].arn]
       }
     }
   }

--- a/aws/s3/main.tf
+++ b/aws/s3/main.tf
@@ -162,7 +162,8 @@ data "aws_iam_policy_document" "bucket_policy" {
         variable = "aws:PrincipalArn"
         values = [
           aws_iam_role.guardduty_malware_protection[0].arn,
-          "arn:aws:iam::*:role/gd-backfill-lambda-*"
+          "arn:aws:iam::*:role/gd-backfill-lambda-*",
+          "arn:aws:sts::*:assumed-role/gd-backfill-lambda-*/*"
         ]
       }
     }

--- a/aws/s3/main.tf
+++ b/aws/s3/main.tf
@@ -127,6 +127,11 @@ data "aws_iam_policy_document" "bucket_policy" {
         variable = "s3:ExistingObjectTag/GuardDutyMalwareScanStatus"
         values   = ["NO_THREATS_FOUND"]
       }
+      condition {
+        test     = "StringNotLike"
+        variable = "aws:PrincipalArn"
+        values   = [aws_iam_role.guardduty_malware_protection[0].arn]
+      }
     }
   }
 
@@ -151,6 +156,11 @@ data "aws_iam_policy_document" "bucket_policy" {
         test     = "Null"
         variable = "s3:ExistingObjectTag/GuardDutyMalwareScanStatus"
         values   = ["true"]
+      }
+      condition {
+        test     = "StringNotLike"
+        variable = "aws:PrincipalArn"
+        values   = [aws_iam_role.guardduty_malware_protection[0].arn]
       }
     }
   }

--- a/aws/s3/main.tf
+++ b/aws/s3/main.tf
@@ -19,42 +19,147 @@ resource "aws_s3_bucket_versioning" "main" {
 data "aws_elb_service_account" "main" {}
 
 locals {
-  writers_policy_json = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : flatten([
-      for writer in var.writers : [
-        {
-          "Effect" : "Allow",
-          "Action" : "s3:PutObject",
-          "Resource" : "${aws_s3_bucket.main.arn}/${writer.prefix}/*",
-          "Principal" : {
-            "AWS" : "${data.aws_elb_service_account.main.arn}"
-          }
-        },
-        {
-          "Effect" : "Allow",
-          "Action" : "s3:PutObject",
-          "Resource" : "${aws_s3_bucket.main.arn}/${writer.prefix}/*",
-          "Principal" : {
-            "Service" : "delivery.logs.amazonaws.com"
-          }
-        },
-        {
-          "Effect" : "Allow",
-          "Action" : "s3:GetBucketAcl",
-          "Resource" : "${aws_s3_bucket.main.arn}",
-          "Principal" : {
-            "Service" : "delivery.logs.amazonaws.com"
-          }
-        }
-      ]
-    ])
-  })
+  has_writers            = length(var.writers) > 0
+  has_malware_policy     = var.file_malwarescanning_enabled
+  has_bucket_policy      = local.has_writers || local.has_malware_policy
+  block_infected_only    = var.file_malwarescanning_enabled && var.allow_downloading_unscanned_files
+  block_all_except_clean = var.file_malwarescanning_enabled && !var.allow_downloading_unscanned_files
 }
 
-resource "aws_s3_bucket_policy" "writers" {
-  count = length(var.writers) > 0 ? 1 : 0
+# --- Writers policy statements ---
+data "aws_iam_policy_document" "bucket_policy" {
+  count = local.has_bucket_policy ? 1 : 0
+
+  # Writers: Allow ELB service account to put objects
+  dynamic "statement" {
+    for_each = var.writers
+    content {
+      effect  = "Allow"
+      actions = ["s3:PutObject"]
+      resources = [
+        "${aws_s3_bucket.main.arn}/${statement.value.prefix}/*",
+      ]
+      principals {
+        type        = "AWS"
+        identifiers = [data.aws_elb_service_account.main.arn]
+      }
+    }
+  }
+
+  # Writers: Allow delivery.logs.amazonaws.com to put objects
+  dynamic "statement" {
+    for_each = var.writers
+    content {
+      effect  = "Allow"
+      actions = ["s3:PutObject"]
+      resources = [
+        "${aws_s3_bucket.main.arn}/${statement.value.prefix}/*",
+      ]
+      principals {
+        type        = "Service"
+        identifiers = ["delivery.logs.amazonaws.com"]
+      }
+    }
+  }
+
+  # Writers: Allow delivery.logs.amazonaws.com to get bucket ACL
+  dynamic "statement" {
+    for_each = local.has_writers ? [1] : []
+    content {
+      effect  = "Allow"
+      actions = ["s3:GetBucketAcl"]
+      resources = [
+        aws_s3_bucket.main.arn,
+      ]
+      principals {
+        type        = "Service"
+        identifiers = ["delivery.logs.amazonaws.com"]
+      }
+    }
+  }
+
+  # --- Malware scanning: Permissive mode ---
+  # Block downloads of objects explicitly tagged as THREATS_FOUND
+  dynamic "statement" {
+    for_each = local.block_infected_only ? [1] : []
+    content {
+      sid    = "DenyInfectedDownloads"
+      effect = "Deny"
+      actions = [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+      ]
+      resources = [
+        "${aws_s3_bucket.main.arn}/*",
+      ]
+      principals {
+        type        = "*"
+        identifiers = ["*"]
+      }
+      condition {
+        test     = "StringEquals"
+        variable = "s3:ExistingObjectTag/GuardDutyMalwareScanStatus"
+        values   = ["THREATS_FOUND"]
+      }
+    }
+  }
+
+  # --- Malware scanning: Strict mode ---
+  # Block downloads of objects NOT tagged as NO_THREATS_FOUND
+  dynamic "statement" {
+    for_each = local.block_all_except_clean ? [1] : []
+    content {
+      sid    = "DenyUnscannedDownloads"
+      effect = "Deny"
+      actions = [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+      ]
+      resources = [
+        "${aws_s3_bucket.main.arn}/*",
+      ]
+      principals {
+        type        = "*"
+        identifiers = ["*"]
+      }
+      condition {
+        test     = "StringNotEquals"
+        variable = "s3:ExistingObjectTag/GuardDutyMalwareScanStatus"
+        values   = ["NO_THREATS_FOUND"]
+      }
+    }
+  }
+
+  # Block downloads of objects missing the scan tag entirely
+  dynamic "statement" {
+    for_each = local.block_all_except_clean ? [1] : []
+    content {
+      sid    = "DenyMissingScanTagDownloads"
+      effect = "Deny"
+      actions = [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+      ]
+      resources = [
+        "${aws_s3_bucket.main.arn}/*",
+      ]
+      principals {
+        type        = "*"
+        identifiers = ["*"]
+      }
+      condition {
+        test     = "Null"
+        variable = "s3:ExistingObjectTag/GuardDutyMalwareScanStatus"
+        values   = ["true"]
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "main" {
+  count = local.has_bucket_policy ? 1 : 0
 
   bucket = aws_s3_bucket.main.id
-  policy = local.writers_policy_json
+  policy = data.aws_iam_policy_document.bucket_policy[0].json
 }
+

--- a/aws/s3/main.tf
+++ b/aws/s3/main.tf
@@ -20,10 +20,10 @@ data "aws_elb_service_account" "main" {}
 
 locals {
   has_writers            = length(var.writers) > 0
-  has_malware_policy     = var.file_malwarescanning_enabled
+  has_malware_policy     = var.file_malwarescanning.enabled
   has_bucket_policy      = local.has_writers || local.has_malware_policy
-  block_infected_only    = var.file_malwarescanning_enabled && var.allow_downloading_unscanned_files
-  block_all_except_clean = var.file_malwarescanning_enabled && !var.allow_downloading_unscanned_files
+  block_infected_only    = var.file_malwarescanning.enabled && var.file_malwarescanning.allow_downloading_unscanned_files
+  block_all_except_clean = var.file_malwarescanning.enabled && !var.file_malwarescanning.allow_downloading_unscanned_files
 }
 
 # --- Writers policy statements ---

--- a/aws/s3/malware_protection.tf
+++ b/aws/s3/malware_protection.tf
@@ -39,12 +39,12 @@ resource "aws_iam_role" "guardduty_malware_protection" {
 data "aws_iam_policy_document" "guardduty_s3_access" {
   count = var.file_malwarescanning.enabled ? 1 : 0
 
-  # Allow reading objects from the bucket
+  # Allow reading objects and bucket configuration, and configuring notifications
   statement {
     actions = [
-      "s3:GetObject",
-      "s3:GetObjectVersion",
+      "s3:Get*",
       "s3:ListBucket",
+      "s3:PutBucketNotification",
     ]
     resources = [
       aws_s3_bucket.main.arn,
@@ -56,12 +56,23 @@ data "aws_iam_policy_document" "guardduty_s3_access" {
   statement {
     actions = [
       "s3:PutObjectTagging",
-      "s3:GetObjectTagging",
       "s3:PutObjectVersionTagging",
-      "s3:GetObjectVersionTagging",
     ]
     resources = [
       "${aws_s3_bucket.main.arn}/*",
+    ]
+  }
+
+  # Allow EventBridge configuration for auto-triggering scans
+  statement {
+    actions = [
+      "events:PutRule",
+      "events:PutTargets",
+      "events:DeleteRule",
+      "events:RemoveTargets"
+    ]
+    resources = [
+      "arn:aws:events:*:*:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
   }
 

--- a/aws/s3/malware_protection.tf
+++ b/aws/s3/malware_protection.tf
@@ -1,0 +1,133 @@
+# -------------------------------------------------------------------
+# GuardDuty Malware Protection for S3
+# https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection-s3.html
+#
+# This can be used independently without enabling the full GuardDuty service.
+# Scan results are published to EventBridge and objects are tagged with:
+#   GuardDutyMalwareScanStatus = NO_THREATS_FOUND | THREATS_FOUND | UNSUPPORTED | ...
+# -------------------------------------------------------------------
+
+data "aws_caller_identity" "current" {
+  count = var.file_malwarescanning_enabled ? 1 : 0
+}
+
+data "aws_region" "current" {
+  count = var.file_malwarescanning_enabled ? 1 : 0
+}
+
+# IAM Role: Trust policy allowing GuardDuty Malware Protection to assume this role
+data "aws_iam_policy_document" "guardduty_assume_role" {
+  count = var.file_malwarescanning_enabled ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["malware-protection-plan.guardduty.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "guardduty_malware_protection" {
+  count = var.file_malwarescanning_enabled ? 1 : 0
+
+  name_prefix        = "gd-malware-"
+  assume_role_policy = data.aws_iam_policy_document.guardduty_assume_role[0].json
+
+  tags = {
+    Name        = "guardduty-malware-protection-${var.bucket_name}"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+# IAM Policy: Permissions for GuardDuty to read objects, write tags, and use KMS
+data "aws_iam_policy_document" "guardduty_s3_access" {
+  count = var.file_malwarescanning_enabled ? 1 : 0
+
+  # Allow reading objects from the bucket
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:ListBucket",
+    ]
+    resources = [
+      aws_s3_bucket.main.arn,
+      "${aws_s3_bucket.main.arn}/*",
+    ]
+  }
+
+  # Allow tagging objects with scan results
+  statement {
+    actions = [
+      "s3:PutObjectTagging",
+      "s3:GetObjectTagging",
+      "s3:PutObjectVersionTagging",
+      "s3:GetObjectVersionTagging",
+    ]
+    resources = [
+      "${aws_s3_bucket.main.arn}/*",
+    ]
+  }
+
+  # Allow publishing events
+  statement {
+    actions = [
+      "events:PutEvents",
+    ]
+    resources = [
+      "arn:aws:events:${data.aws_region.current[0].region}:${data.aws_caller_identity.current[0].account_id}:event-bus/default",
+    ]
+  }
+
+  # If KMS encryption is enabled, allow GuardDuty to decrypt objects
+  dynamic "statement" {
+    for_each = var.enable_encryption ? [1] : []
+    content {
+      actions = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey",
+      ]
+      resources = [
+        module.kms_key[0].arn,
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "guardduty_s3_access" {
+  count = var.file_malwarescanning_enabled ? 1 : 0
+
+  name_prefix = "gd-s3-access-"
+  role        = aws_iam_role.guardduty_malware_protection[0].id
+  policy      = data.aws_iam_policy_document.guardduty_s3_access[0].json
+}
+
+# The GuardDuty Malware Protection Plan itself
+resource "aws_guardduty_malware_protection_plan" "main" {
+  count = var.file_malwarescanning_enabled ? 1 : 0
+
+  role = aws_iam_role.guardduty_malware_protection[0].arn
+
+  protected_resource {
+    s3_bucket {
+      bucket_name = aws_s3_bucket.main.id
+    }
+  }
+
+  actions {
+    tagging {
+      status = "ENABLED"
+    }
+  }
+
+  tags = {
+    Name        = "malware-protection-${var.bucket_name}"
+    Project     = var.project
+    Environment = var.environment
+  }
+
+  depends_on = [aws_iam_role_policy.guardduty_s3_access]
+}

--- a/aws/s3/malware_protection.tf
+++ b/aws/s3/malware_protection.tf
@@ -3,17 +3,10 @@
 # https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection-s3.html
 #
 # This can be used independently without enabling the full GuardDuty service.
-# Scan results are published to EventBridge and objects are tagged with:
+# Scan results are automatically published to the default EventBridge bus
+# and objects are tagged with:
 #   GuardDutyMalwareScanStatus = NO_THREATS_FOUND | THREATS_FOUND | UNSUPPORTED | ...
 # -------------------------------------------------------------------
-
-data "aws_caller_identity" "current" {
-  count = var.file_malwarescanning_enabled ? 1 : 0
-}
-
-data "aws_region" "current" {
-  count = var.file_malwarescanning_enabled ? 1 : 0
-}
 
 # IAM Role: Trust policy allowing GuardDuty Malware Protection to assume this role
 data "aws_iam_policy_document" "guardduty_assume_role" {
@@ -69,16 +62,6 @@ data "aws_iam_policy_document" "guardduty_s3_access" {
     ]
     resources = [
       "${aws_s3_bucket.main.arn}/*",
-    ]
-  }
-
-  # Allow publishing events
-  statement {
-    actions = [
-      "events:PutEvents",
-    ]
-    resources = [
-      "arn:aws:events:${data.aws_region.current[0].region}:${data.aws_caller_identity.current[0].account_id}:event-bus/default",
     ]
   }
 

--- a/aws/s3/malware_protection.tf
+++ b/aws/s3/malware_protection.tf
@@ -63,6 +63,17 @@ data "aws_iam_policy_document" "guardduty_s3_access" {
     ]
   }
 
+  # Allow GuardDuty to put a validation object to verify permissions
+  # see https://docs.aws.amazon.com/guardduty/latest/ug/troubleshoot-s3-malware-protection-status-errors.html
+  statement {
+    actions = [
+      "s3:PutObject",
+    ]
+    resources = [
+      "${aws_s3_bucket.main.arn}/malware-protection-resource-validation-object"
+    ]
+  }
+
   # Allow EventBridge configuration for auto-triggering scans
   statement {
     actions = [

--- a/aws/s3/malware_protection.tf
+++ b/aws/s3/malware_protection.tf
@@ -10,7 +10,7 @@
 
 # IAM Role: Trust policy allowing GuardDuty Malware Protection to assume this role
 data "aws_iam_policy_document" "guardduty_assume_role" {
-  count = var.file_malwarescanning_enabled ? 1 : 0
+  count = var.file_malwarescanning.enabled ? 1 : 0
 
   statement {
     actions = ["sts:AssumeRole"]
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "guardduty_assume_role" {
 }
 
 resource "aws_iam_role" "guardduty_malware_protection" {
-  count = var.file_malwarescanning_enabled ? 1 : 0
+  count = var.file_malwarescanning.enabled ? 1 : 0
 
   name_prefix        = "gd-malware-"
   assume_role_policy = data.aws_iam_policy_document.guardduty_assume_role[0].json
@@ -37,7 +37,7 @@ resource "aws_iam_role" "guardduty_malware_protection" {
 
 # IAM Policy: Permissions for GuardDuty to read objects, write tags, and use KMS
 data "aws_iam_policy_document" "guardduty_s3_access" {
-  count = var.file_malwarescanning_enabled ? 1 : 0
+  count = var.file_malwarescanning.enabled ? 1 : 0
 
   # Allow reading objects from the bucket
   statement {
@@ -81,7 +81,7 @@ data "aws_iam_policy_document" "guardduty_s3_access" {
 }
 
 resource "aws_iam_role_policy" "guardduty_s3_access" {
-  count = var.file_malwarescanning_enabled ? 1 : 0
+  count = var.file_malwarescanning.enabled ? 1 : 0
 
   name_prefix = "gd-s3-access-"
   role        = aws_iam_role.guardduty_malware_protection[0].id
@@ -90,7 +90,7 @@ resource "aws_iam_role_policy" "guardduty_s3_access" {
 
 # The GuardDuty Malware Protection Plan itself
 resource "aws_guardduty_malware_protection_plan" "main" {
-  count = var.file_malwarescanning_enabled ? 1 : 0
+  count = var.file_malwarescanning.enabled ? 1 : 0
 
   role = aws_iam_role.guardduty_malware_protection[0].arn
 

--- a/aws/s3/variables.tf
+++ b/aws/s3/variables.tf
@@ -37,14 +37,14 @@ variable "writers" {
   default = []
 }
 
-variable "file_malwarescanning_enabled" {
-  description = "Enable AWS GuardDuty Malware Protection for S3 on this bucket. Scans all newly uploaded objects for malware and tags them with scan results."
-  type        = bool
-  default     = false
-}
-
-variable "allow_downloading_unscanned_files" {
-  description = "If true, only blocks downloads of files tagged as INFECTED. If false, blocks downloads of any file not explicitly tagged as CLEAN. Set to true initially when enabling scanning on existing buckets, then switch to false after backfilling scans."
-  type        = bool
-  default     = true
+variable "file_malwarescanning" {
+  description = "Configuration for AWS GuardDuty Malware Protection for S3."
+  type = object({
+    enabled                           = bool
+    allow_downloading_unscanned_files = bool
+  })
+  default = {
+    enabled                           = false
+    allow_downloading_unscanned_files = true
+  }
 }

--- a/aws/s3/variables.tf
+++ b/aws/s3/variables.tf
@@ -36,3 +36,15 @@ variable "writers" {
   }))
   default = []
 }
+
+variable "file_malwarescanning_enabled" {
+  description = "Enable AWS GuardDuty Malware Protection for S3 on this bucket. Scans all newly uploaded objects for malware and tags them with scan results."
+  type        = bool
+  default     = false
+}
+
+variable "allow_downloading_unscanned_files" {
+  description = "If true, only blocks downloads of files tagged as INFECTED. If false, blocks downloads of any file not explicitly tagged as CLEAN. Set to true initially when enabling scanning on existing buckets, then switch to false after backfilling scans."
+  type        = bool
+  default     = true
+}

--- a/aws/s3/variables.tf
+++ b/aws/s3/variables.tf
@@ -44,7 +44,7 @@ variable "file_malwarescanning" {
     allow_downloading_unscanned_files = bool
   })
   default = {
-    enabled                           = false
-    allow_downloading_unscanned_files = true
+    enabled                           = true
+    allow_downloading_unscanned_files = false
   }
 }

--- a/aws/s3/versions.tf
+++ b/aws/s3/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 5.0"
     }
   }
   required_version = ">= 1.0"

--- a/aws/waf/variables.tf
+++ b/aws/waf/variables.tf
@@ -42,7 +42,7 @@ variable "waf_rules" {
     text_transformation   = optional(string, "NONE")
 
     # For managed_rule_group rules
-    managed_rule_group_name = optional(string)       # e.g., "AWSManagedRulesCommonRuleSet"
+    managed_rule_group_name = optional(string) # e.g., "AWSManagedRulesCommonRuleSet"
     vendor_name             = optional(string, "AWS")
     excluded_rules          = optional(list(string), []) # Rules to exclude (set to COUNT), e.g., ["NoUserAgent_HEADER"]
 
@@ -53,7 +53,7 @@ variable "waf_rules" {
       match_value           = string                     # The value to match
       positional_constraint = optional(string, "EXACTLY")
       text_transformation   = optional(string, "NONE")
-      negate                = optional(bool, false)      # Wraps the statement in not_statement
+      negate                = optional(bool, false) # Wraps the statement in not_statement
     })), [])
 
     # For or_statement rules (byte_match only)
@@ -64,7 +64,7 @@ variable "waf_rules" {
       match_value           = string                     # The value to match
       positional_constraint = optional(string, "EXACTLY")
       text_transformation   = optional(string, "NONE")
-      negate                = optional(bool, false)      # Wraps the statement in not_statement
+      negate                = optional(bool, false) # Wraps the statement in not_statement
     })), [])
 
   }))

--- a/script/backfill_malware_scan.mjs
+++ b/script/backfill_malware_scan.mjs
@@ -1,7 +1,5 @@
-import { GuardDutyClient, StartMalwareScanCommand } from "@aws-sdk/client-guardduty";
-import { S3Client, GetObjectTaggingCommand } from "@aws-sdk/client-s3";
+import { S3Client, GetObjectTaggingCommand, HeadObjectCommand, CopyObjectCommand } from "@aws-sdk/client-s3";
 
-const guardduty = new GuardDutyClient();
 const s3 = new S3Client();
 
 export const handler = async (event) => {
@@ -30,23 +28,43 @@ export const handler = async (event) => {
           };
         }
 
-        // Trigger GuardDuty malware scan
-        await guardduty.send(
-          new StartMalwareScanCommand({
-            ResourceArn: `arn:aws:s3:::${bucket}/${key}`,
-          })
-        );
+        // Fetch existing metadata to preserve it
+        const head = await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+
+        // Perform an in-place copy to trigger a new ObjectCreated event.
+        // GuardDuty Malware Protection uses EventBridge to listen for this event.
+        const sourceUrl = encodeURIComponent(`${bucket}/${key}`).replace(/%2F/g, "/");
+        const copyParams = {
+          Bucket: bucket,
+          CopySource: sourceUrl,
+          Key: key,
+          MetadataDirective: "REPLACE",
+          Metadata: {
+            ...(head.Metadata || {}),
+            "gd-backfilled": "true" // Small mutation to bypass S3 identical-copy blocker
+          }
+        };
+
+        // Conditionally apply head object headers to prevent SDK crash from undefined properties
+        if (head.ContentType) copyParams.ContentType = head.ContentType;
+        if (head.CacheControl) copyParams.CacheControl = head.CacheControl;
+        if (head.ContentDisposition) copyParams.ContentDisposition = head.ContentDisposition;
+        if (head.ContentEncoding) copyParams.ContentEncoding = head.ContentEncoding;
+        if (head.ContentLanguage) copyParams.ContentLanguage = head.ContentLanguage;
+
+        await s3.send(new CopyObjectCommand(copyParams));
 
         return {
           taskId: task.taskId,
           resultCode: "Succeeded",
-          resultString: "ScanQueued",
+          resultString: "CopyTriggered",
         };
       } catch (err) {
+        const errDetails = JSON.stringify(err, Object.getOwnPropertyNames(err)) || "Unknown SDK error";
         return {
           taskId: task.taskId,
           resultCode: "PermanentFailure",
-          resultString: err.message?.substring(0, 256) || "UnknownError",
+          resultString: errDetails.substring(0, 256),
         };
       }
     })

--- a/script/backfill_malware_scan.mjs
+++ b/script/backfill_malware_scan.mjs
@@ -1,0 +1,61 @@
+import { GuardDutyClient, StartMalwareScanCommand } from "@aws-sdk/client-guardduty";
+import { S3Client, GetObjectTaggingCommand } from "@aws-sdk/client-s3";
+
+const guardduty = new GuardDutyClient();
+const s3 = new S3Client();
+
+export const handler = async (event) => {
+  const invocationId = event.invocationId;
+  const invocationSchemaVersion = event.invocationSchemaVersion;
+
+  const results = await Promise.all(
+    event.tasks.map(async (task) => {
+      const bucket = task.s3BucketArn.split(":::")[1];
+      const key = decodeURIComponent(task.s3Key.replace(/\+/g, " "));
+
+      try {
+        // Skip objects that already have a scan tag
+        const tagging = await s3.send(
+          new GetObjectTaggingCommand({ Bucket: bucket, Key: key })
+        );
+        const alreadyScanned = tagging.TagSet?.some(
+          (t) => t.Key === "GuardDutyMalwareScanStatus"
+        );
+
+        if (alreadyScanned) {
+          return {
+            taskId: task.taskId,
+            resultCode: "Succeeded",
+            resultString: "AlreadyScanned",
+          };
+        }
+
+        // Trigger GuardDuty malware scan
+        await guardduty.send(
+          new StartMalwareScanCommand({
+            ResourceArn: `arn:aws:s3:::${bucket}/${key}`,
+          })
+        );
+
+        return {
+          taskId: task.taskId,
+          resultCode: "Succeeded",
+          resultString: "ScanQueued",
+        };
+      } catch (err) {
+        return {
+          taskId: task.taskId,
+          resultCode: "PermanentFailure",
+          resultString: err.message?.substring(0, 256) || "UnknownError",
+        };
+      }
+    })
+  );
+
+  return {
+    invocationSchemaVersion,
+    treatMissingKeysAs: "PermanentFailure",
+    invocationId,
+    results,
+  };
+};

--- a/script/backfill_s3_malware_scan.sh
+++ b/script/backfill_s3_malware_scan.sh
@@ -95,4 +95,4 @@ done
 echo ""
 echo "Done. Processed: $TOTAL | Scanned: $SCANNED | Skipped (already tagged): $SKIPPED"
 echo ""
-echo "Once complete, set: allow_downloading_unscanned_files = false"
+echo "Once complete, you can remove the allow_downloading_unscanned_files = true override from Terraform."

--- a/script/backfill_s3_malware_scan.sh
+++ b/script/backfill_s3_malware_scan.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env zsh
 #
-# Backfill GuardDuty Malware Scans for Existing S3 Objects
+# Backfill GuardDuty Malware Scans via S3 Batch Operations
 #
-# Iterates through all objects in a bucket, skips any that are already
-# tagged with a scan result, and triggers a scan for the rest.
-# Safe to stop and re-run — already-scanned objects are skipped.
+# This script provisions a temporary Lambda function and IAM roles,
+# generates an S3 object manifest, and submits an S3 Batch Operations
+# job to scan all existing objects using GuardDuty.
 #
 # Usage:
 #   export AWS_PROFILE=your-profile
-#   ./backfill_s3_malware_scan.sh <bucket-name> [--prefix <prefix>] [--region <region>]
+#   ./script/backfill_s3_malware_scan.sh <bucket-name> [--region <region>]
 #
 
 set -euo pipefail
@@ -20,79 +20,237 @@ if [[ -z "${AWS_PROFILE:-}" ]]; then
 fi
 
 if [[ -z "${1:-}" ]]; then
-  echo "Usage: $0 <bucket-name> [--prefix <prefix>] [--region <region>]"
+  echo "Usage: $0 <bucket-name> [--region <region>]"
   exit 1
 fi
 
 BUCKET="$1"; shift
-PREFIX=""
 REGION_ARGS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --prefix) PREFIX="$2"; shift 2 ;;
     --region) REGION_ARGS=(--region "$2"); shift 2 ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
 done
 
-echo "Bucket:  s3://$BUCKET/${PREFIX}"
+ACCOUNT_ID=$(aws sts get-caller-identity "${REGION_ARGS[@]}" --query Account --output text)
+REGION=$(aws configure get region "${REGION_ARGS[@]}" 2>/dev/null || echo "us-east-1")
+if [[ ${#REGION_ARGS[@]} -gt 0 ]]; then
+  REGION="${REGION_ARGS[2]}"
+fi
+
+LAMBDA_NAME="gd-backfill-${BUCKET}"
+LAMBDA_ROLE="gd-backfill-lambda-${BUCKET}"
+BATCH_ROLE="gd-batch-ops-${BUCKET}"
+
+echo "Bucket:  s3://$BUCKET"
 echo "Profile: $AWS_PROFILE"
+echo "Region:  $REGION"
 echo ""
 
-TOTAL=0
-SCANNED=0
-SKIPPED=0
+# -------------------------------------------------------------------
+# 1. Provide Lambda IAM Role
+# -------------------------------------------------------------------
+echo "Setting up IAM role for Lambda ($LAMBDA_ROLE)..."
+if ! aws iam get-role --role-name "$LAMBDA_ROLE" >/dev/null 2>&1; then
+  aws iam create-role --role-name "$LAMBDA_ROLE" \
+    --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"}}]}' \
+    >/dev/null
+  echo "  Created role"
+fi
+
+aws iam put-role-policy --role-name "$LAMBDA_ROLE" --policy-name "gd-backfill-lambda-policy" \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": ["s3:GetObjectTagging", "s3:GetObjectVersionTagging"],
+        "Resource": "arn:aws:s3:::'"$BUCKET"'/*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["guardduty:StartMalwareScan"],
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+        "Resource": "arn:aws:logs:*:*:*"
+      }
+    ]
+  }'
+
+LAMBDA_ROLE_ARN=$(aws iam get-role --role-name "$LAMBDA_ROLE" --query Role.Arn --output text)
+
+# -------------------------------------------------------------------
+# 2. Package and Deploy Lambda
+# -------------------------------------------------------------------
+echo "Setting up Lambda function ($LAMBDA_NAME)..."
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ZIP_FILE="/tmp/${LAMBDA_NAME}.zip"
+cd "$DIR" && zip -q -j "$ZIP_FILE" "backfill_malware_scan.mjs" && cd - >/dev/null
+
+if aws lambda get-function --function-name "$LAMBDA_NAME" "${REGION_ARGS[@]}" >/dev/null 2>&1; then
+  aws lambda update-function-code --function-name "$LAMBDA_NAME" "${REGION_ARGS[@]}" \
+    --zip-file "fileb://$ZIP_FILE" >/dev/null
+  echo "  Updated existing function"
+else
+  echo "  Waiting for IAM role propagation (10s)..."
+  sleep 10
+  aws lambda create-function --function-name "$LAMBDA_NAME" "${REGION_ARGS[@]}" \
+    --runtime "nodejs22.x" --role "$LAMBDA_ROLE_ARN" --handler "backfill_malware_scan.handler" \
+    --timeout 300 --zip-file "fileb://$ZIP_FILE" >/dev/null
+  echo "  Created function"
+fi
+rm -f "$ZIP_FILE"
+LAMBDA_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${LAMBDA_NAME}"
+
+# -------------------------------------------------------------------
+# 3. Provide S3 Batch Operations IAM Role
+# -------------------------------------------------------------------
+echo "Setting up IAM role for S3 Batch Operations ($BATCH_ROLE)..."
+if ! aws iam get-role --role-name "$BATCH_ROLE" >/dev/null 2>&1; then
+  aws iam create-role --role-name "$BATCH_ROLE" \
+    --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":"batchoperations.s3.amazonaws.com"}}]}' \
+    >/dev/null
+  echo "  Created role"
+fi
+
+aws iam put-role-policy --role-name "$BATCH_ROLE" --policy-name "gd-batch-ops-policy" \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": ["lambda:InvokeFunction"],
+        "Resource": "'"$LAMBDA_ARN"'"
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["s3:GetObject", "s3:GetObjectVersion", "s3:PutObject"],
+        "Resource": "arn:aws:s3:::'"$BUCKET"'/*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["s3:ListBucket"],
+        "Resource": "arn:aws:s3:::'"$BUCKET"'"
+      }
+    ]
+  }'
+
+BATCH_ROLE_ARN=$(aws iam get-role --role-name "$BATCH_ROLE" --query Role.Arn --output text)
+
+# Give Batch ops IAM role time to propagate before submitting the job
+echo "  Waiting for IAM policy propagation (10s)..."
+sleep 10
+
+# -------------------------------------------------------------------
+# 4. Generate manifest CSV and upload to S3
+# -------------------------------------------------------------------
+MANIFEST_KEY=".malware-scan-backfill/manifest-$(date +%Y%m%d-%H%M%S).csv"
+REPORT_PREFIX=".malware-scan-backfill/reports"
+
+echo ""
+echo "Generating object manifest for bucket..."
+MANIFEST_FILE=$(mktemp)
 TOKEN=""
+OBJECT_COUNT=0
 
 while true; do
-  # Build the list command for this page
   CMD=(aws s3api list-objects-v2 --bucket "$BUCKET" --output json "${REGION_ARGS[@]}")
-  [[ -n "$PREFIX" ]] && CMD+=(--prefix "$PREFIX")
   [[ -n "$TOKEN" ]] && CMD+=(--starting-token "$TOKEN")
 
   PAGE=$("${CMD[@]}" 2>/dev/null)
 
-  KEYS=$(echo "$PAGE" | python3 -c "
+  echo "$PAGE" | python3 -c "
 import sys, json
-for obj in json.load(sys.stdin).get('Contents', []):
-    print(obj['Key'])
+data = json.load(sys.stdin)
+for obj in data.get('Contents', []):
+    print('${BUCKET},' + obj['Key'])
+" >> "$MANIFEST_FILE" 2>/dev/null
+
+  PAGE_COUNT=$(echo "$PAGE" | python3 -c "
+import sys, json
+print(len(json.load(sys.stdin).get('Contents', [])))
 " 2>/dev/null)
+  OBJECT_COUNT=$((OBJECT_COUNT + PAGE_COUNT))
 
-  [[ -z "$KEYS" ]] && break
-
-  echo "$KEYS" | while IFS= read -r KEY; do
-    [[ -z "$KEY" ]] && continue
-    TOTAL=$((TOTAL + 1))
-
-    # Check if already tagged
-    TAGS=$(aws s3api get-object-tagging --bucket "$BUCKET" --key "$KEY" "${REGION_ARGS[@]}" --output json 2>/dev/null || echo '{}')
-    if echo "$TAGS" | grep -q "GuardDutyMalwareScanStatus"; then
-      SKIPPED=$((SKIPPED + 1))
-      continue
-    fi
-
-    # Trigger scan
-    if aws guardduty start-malware-scan \
-      --resource-arn "arn:aws:s3:::${BUCKET}/${KEY}" \
-      "${REGION_ARGS[@]}" > /dev/null 2>&1; then
-      SCANNED=$((SCANNED + 1))
-      echo "[$SCANNED] Queued: $KEY"
-    else
-      echo "FAILED: $KEY" >&2
-    fi
-  done
-
-  # Next page
   TOKEN=$(echo "$PAGE" | python3 -c "
 import sys, json
 print(json.load(sys.stdin).get('NextContinuationToken', ''))
 " 2>/dev/null)
 
   [[ -z "$TOKEN" ]] && break
+  echo "  ... listed $OBJECT_COUNT objects so far"
 done
 
+if [[ $OBJECT_COUNT -eq 0 ]]; then
+  echo "No objects found in the bucket."
+  rm -f "$MANIFEST_FILE"
+  exit 0
+fi
+
+echo "Total objects: $OBJECT_COUNT"
+echo "Uploading manifest to s3://$BUCKET/$MANIFEST_KEY..."
+
+aws s3 cp "$MANIFEST_FILE" "s3://$BUCKET/$MANIFEST_KEY" "${REGION_ARGS[@]}" --quiet
+MANIFEST_ETAG=$(aws s3api head-object --bucket "$BUCKET" --key "$MANIFEST_KEY" "${REGION_ARGS[@]}" --query ETag --output text)
+rm -f "$MANIFEST_FILE"
+
+# -------------------------------------------------------------------
+# 5. Create S3 Batch Operations job
+# -------------------------------------------------------------------
 echo ""
-echo "Done. Processed: $TOTAL | Scanned: $SCANNED | Skipped (already tagged): $SKIPPED"
+echo "Creating S3 Batch Operations job..."
+
+JOB_ID=$(aws s3control create-job \
+  --account-id "$ACCOUNT_ID" \
+  --operation "{
+    \"LambdaInvoke\": {
+      \"FunctionArn\": \"$LAMBDA_ARN\"
+    }
+  }" \
+  --manifest "{
+    \"Spec\": {
+      \"Format\": \"S3BatchOperations_CSV_20180820\",
+      \"Fields\": [\"Bucket\", \"Key\"]
+    },
+    \"Location\": {
+      \"ObjectArn\": \"arn:aws:s3:::${BUCKET}/${MANIFEST_KEY}\",
+      \"ETag\": $MANIFEST_ETAG
+    }
+  }" \
+  --report "{
+    \"Bucket\": \"arn:aws:s3:::${BUCKET}\",
+    \"Prefix\": \"${REPORT_PREFIX}\",
+    \"Format\": \"Report_CSV_20180820\",
+    \"Enabled\": true,
+    \"ReportScope\": \"FailedTasksOnly\"
+  }" \
+  --priority 10 \
+  --role-arn "$BATCH_ROLE_ARN" \
+  --description "GuardDuty malware scan backfill for $BUCKET" \
+  --no-confirmation-required \
+  "${REGION_ARGS[@]}" \
+  --query JobId --output text)
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Batch job created!"
+echo "  Job ID:  $JOB_ID"
+echo "  Objects: $OBJECT_COUNT"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "The job runs entirely in AWS — you can close this terminal."
+echo "Monitor progress in the AWS Console → S3 → Batch Operations."
 echo ""
 echo "Once complete, you can remove the allow_downloading_unscanned_files = true override from Terraform."
+echo ""
+echo "Cleanup (optional) when job is 100% complete:"
+echo "  aws lambda delete-function --function-name $LAMBDA_NAME"
+echo "  aws iam delete-role-policy --role-name $LAMBDA_ROLE --policy-name gd-backfill-lambda-policy"
+echo "  aws iam delete-role --role-name $LAMBDA_ROLE"
+echo "  aws iam delete-role-policy --role-name $BATCH_ROLE --policy-name gd-batch-ops-policy"
+echo "  aws iam delete-role --role-name $BATCH_ROLE"

--- a/script/backfill_s3_malware_scan.sh
+++ b/script/backfill_s3_malware_scan.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env zsh
+#
+# Backfill GuardDuty Malware Scans for Existing S3 Objects
+#
+# Iterates through all objects in a bucket, skips any that are already
+# tagged with a scan result, and triggers a scan for the rest.
+# Safe to stop and re-run — already-scanned objects are skipped.
+#
+# Usage:
+#   export AWS_PROFILE=your-profile
+#   ./backfill_s3_malware_scan.sh <bucket-name> [--prefix <prefix>] [--region <region>]
+#
+
+set -euo pipefail
+
+if [[ -z "${AWS_PROFILE:-}" ]]; then
+  echo "Error: AWS_PROFILE is not set."
+  echo "  export AWS_PROFILE=your-profile"
+  exit 1
+fi
+
+if [[ -z "${1:-}" ]]; then
+  echo "Usage: $0 <bucket-name> [--prefix <prefix>] [--region <region>]"
+  exit 1
+fi
+
+BUCKET="$1"; shift
+PREFIX=""
+REGION_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prefix) PREFIX="$2"; shift 2 ;;
+    --region) REGION_ARGS=(--region "$2"); shift 2 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+echo "Bucket:  s3://$BUCKET/${PREFIX}"
+echo "Profile: $AWS_PROFILE"
+echo ""
+
+TOTAL=0
+SCANNED=0
+SKIPPED=0
+TOKEN=""
+
+while true; do
+  # Build the list command for this page
+  CMD=(aws s3api list-objects-v2 --bucket "$BUCKET" --output json "${REGION_ARGS[@]}")
+  [[ -n "$PREFIX" ]] && CMD+=(--prefix "$PREFIX")
+  [[ -n "$TOKEN" ]] && CMD+=(--starting-token "$TOKEN")
+
+  PAGE=$("${CMD[@]}" 2>/dev/null)
+
+  KEYS=$(echo "$PAGE" | python3 -c "
+import sys, json
+for obj in json.load(sys.stdin).get('Contents', []):
+    print(obj['Key'])
+" 2>/dev/null)
+
+  [[ -z "$KEYS" ]] && break
+
+  echo "$KEYS" | while IFS= read -r KEY; do
+    [[ -z "$KEY" ]] && continue
+    TOTAL=$((TOTAL + 1))
+
+    # Check if already tagged
+    TAGS=$(aws s3api get-object-tagging --bucket "$BUCKET" --key "$KEY" "${REGION_ARGS[@]}" --output json 2>/dev/null || echo '{}')
+    if echo "$TAGS" | grep -q "GuardDutyMalwareScanStatus"; then
+      SKIPPED=$((SKIPPED + 1))
+      continue
+    fi
+
+    # Trigger scan
+    if aws guardduty start-malware-scan \
+      --resource-arn "arn:aws:s3:::${BUCKET}/${KEY}" \
+      "${REGION_ARGS[@]}" > /dev/null 2>&1; then
+      SCANNED=$((SCANNED + 1))
+      echo "[$SCANNED] Queued: $KEY"
+    else
+      echo "FAILED: $KEY" >&2
+    fi
+  done
+
+  # Next page
+  TOKEN=$(echo "$PAGE" | python3 -c "
+import sys, json
+print(json.load(sys.stdin).get('NextContinuationToken', ''))
+" 2>/dev/null)
+
+  [[ -z "$TOKEN" ]] && break
+done
+
+echo ""
+echo "Done. Processed: $TOTAL | Scanned: $SCANNED | Skipped (already tagged): $SKIPPED"
+echo ""
+echo "Once complete, set: allow_downloading_unscanned_files = false"

--- a/script/backfill_s3_malware_scan.sh
+++ b/script/backfill_s3_malware_scan.sh
@@ -8,7 +8,7 @@
 #
 # Usage:
 #   export AWS_PROFILE=your-profile
-#   ./script/backfill_s3_malware_scan.sh <bucket-name> [--region <region>]
+#   ./script/backfill_s3_malware_scan.sh --bucket <bucket-name> [--region <region>]
 #
 
 set -euo pipefail
@@ -19,20 +19,21 @@ if [[ -z "${AWS_PROFILE:-}" ]]; then
   exit 1
 fi
 
-if [[ -z "${1:-}" ]]; then
-  echo "Usage: $0 <bucket-name> [--region <region>]"
-  exit 1
-fi
-
-BUCKET="$1"; shift
+BUCKET=""
 REGION_ARGS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --region) REGION_ARGS=(--region "$2"); shift 2 ;;
+    --bucket|-b) BUCKET="$2"; shift 2 ;;
+    --region|-r) REGION_ARGS=(--region "$2"); shift 2 ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
 done
+
+if [[ -z "$BUCKET" ]]; then
+  echo "Usage: $0 --bucket <bucket-name> [--region <region>]"
+  exit 1
+fi
 
 ACCOUNT_ID=$(aws sts get-caller-identity "${REGION_ARGS[@]}" --query Account --output text)
 REGION=$(aws configure get region "${REGION_ARGS[@]}" 2>/dev/null || echo "us-east-1")
@@ -40,13 +41,46 @@ if [[ ${#REGION_ARGS[@]} -gt 0 ]]; then
   REGION="${REGION_ARGS[2]}"
 fi
 
-LAMBDA_NAME="gd-backfill-${BUCKET}"
-LAMBDA_ROLE="gd-backfill-lambda-${BUCKET}"
-BATCH_ROLE="gd-batch-ops-${BUCKET}"
+SAFE_BUCKET_NAME="${BUCKET//./-}"
+LAMBDA_NAME="gd-backfill-${SAFE_BUCKET_NAME}"
+LAMBDA_ROLE="gd-backfill-lambda-${SAFE_BUCKET_NAME}"
+BATCH_ROLE="gd-batch-ops-${SAFE_BUCKET_NAME}"
 
 echo "Bucket:  s3://$BUCKET"
 echo "Profile: $AWS_PROFILE"
 echo "Region:  $REGION"
+echo ""
+
+# -------------------------------------------------------------------
+# Pre-flight: Ensure bucket policy does not block unscanned file access
+# The backfill Lambda needs to read+copy objects that don't yet have
+# scan tags. If allow_downloading_unscanned_files = false, the Deny
+# policy blocks the Lambda. There is no reliable way to exempt it
+# because S3 Batch Operations → Lambda is a service-chained invocation
+# where aws:PrincipalArn matching is unreliable.
+# -------------------------------------------------------------------
+echo "Checking bucket policy..."
+BUCKET_POLICY=$(aws s3api get-bucket-policy --bucket "$BUCKET" "${REGION_ARGS[@]}" --query Policy --output text 2>/dev/null || echo "{}")
+if echo "$BUCKET_POLICY" | grep -q "DenyUnscannedDownloads\|DenyMissingScanTagDownloads"; then
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  ERROR: Bucket policy blocks unscanned file access!"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "  Before running the backfill, you must temporarily set:"
+  echo ""
+  echo "    file_malwarescanning = {"
+  echo "      enabled                           = true"
+  echo "      allow_downloading_unscanned_files = true"
+  echo "    }"
+  echo ""
+  echo "  Then run: terraform apply"
+  echo "  Then re-run this script."
+  echo ""
+  echo "  After the backfill job completes 100%, flip it back to false."
+  exit 1
+fi
+echo "  OK — no strict deny blocks detected."
 echo ""
 
 # -------------------------------------------------------------------
@@ -66,12 +100,21 @@ aws iam put-role-policy --role-name "$LAMBDA_ROLE" --policy-name "gd-backfill-la
     "Statement": [
       {
         "Effect": "Allow",
-        "Action": ["s3:GetObjectTagging", "s3:GetObjectVersionTagging"],
+        "Action": [
+          "s3:GetObjectTagging",
+          "s3:GetObjectVersionTagging",
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:PutObjectTagging"
+        ],
         "Resource": "arn:aws:s3:::'"$BUCKET"'/*"
       },
       {
         "Effect": "Allow",
-        "Action": ["guardduty:StartMalwareScan"],
+        "Action": [
+          "kms:Decrypt",
+          "kms:GenerateDataKey"
+        ],
         "Resource": "*"
       },
       {
@@ -88,13 +131,15 @@ LAMBDA_ROLE_ARN=$(aws iam get-role --role-name "$LAMBDA_ROLE" --query Role.Arn -
 # 2. Package and Deploy Lambda
 # -------------------------------------------------------------------
 echo "Setting up Lambda function ($LAMBDA_NAME)..."
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIP_FILE="/tmp/${LAMBDA_NAME}.zip"
 cd "$DIR" && zip -q -j "$ZIP_FILE" "backfill_malware_scan.mjs" && cd - >/dev/null
 
 if aws lambda get-function --function-name "$LAMBDA_NAME" "${REGION_ARGS[@]}" >/dev/null 2>&1; then
   aws lambda update-function-code --function-name "$LAMBDA_NAME" "${REGION_ARGS[@]}" \
     --zip-file "fileb://$ZIP_FILE" >/dev/null
+  echo "  Waiting for Lambda function update to propagate globally..."
+  aws lambda wait function-updated --function-name "$LAMBDA_NAME" "${REGION_ARGS[@]}"
   echo "  Updated existing function"
 else
   echo "  Waiting for IAM role propagation (10s)..."
@@ -195,7 +240,7 @@ fi
 echo "Total objects: $OBJECT_COUNT"
 echo "Uploading manifest to s3://$BUCKET/$MANIFEST_KEY..."
 
-aws s3 cp "$MANIFEST_FILE" "s3://$BUCKET/$MANIFEST_KEY" "${REGION_ARGS[@]}" --quiet
+aws s3 cp "$MANIFEST_FILE" "s3://$BUCKET/$MANIFEST_KEY" "${REGION_ARGS[@]}" --sse AES256 --quiet
 MANIFEST_ETAG=$(aws s3api head-object --bucket "$BUCKET" --key "$MANIFEST_KEY" "${REGION_ARGS[@]}" --query ETag --output text)
 rm -f "$MANIFEST_FILE"
 


### PR DESCRIPTION
<!-- If this branch is in progress, create a Draft PR. -->

#### Summary

Adds AWS GuardDuty Malware Protection for S3 to allow scanning uploaded files for malware.

https://docs.aws.amazon.com/guardduty/latest/ug/gdu-malware-protection-s3.html

https://aws.amazon.com/video/watch/8fba551cd9c/

#### Motivation

can't trust users.

#### Testing

a tested file

<img width="1123" height="474" alt="Screenshot 2026-03-31 at 12 21 52" src="https://github.com/user-attachments/assets/5b2f4a77-ceab-4310-ae8b-3eca23f554e9" />

backfilling job

<img width="1618" height="320" alt="Screenshot 2026-03-31 at 12 21 20" src="https://github.com/user-attachments/assets/f17bb44c-e0e9-421e-bd2a-4244fe868463" />
